### PR TITLE
build of nativescript currently fails if @ngrx/store is not locked to 1.3.3

### DIFF
--- a/src/nativescript/package.json
+++ b/src/nativescript/package.json
@@ -22,7 +22,7 @@
 		"start.android.windows": "npm run prepare.windows & tns emulate android"
 	},
 	"dependencies": {
-		"@ngrx/store": "^1.3.2",
+		"@ngrx/store": "1.3.3",
 		"angular2": "2.0.0-beta.14",
 		"angulartics2": "1.0.8",
 		"es6-promise": "^3.0.2",


### PR DESCRIPTION
.. its as simple as that ;-)
