### PR TITLE
i18n-german

### DIFF
--- a/src/client/app/frameworks/app.framework/services/app-config.service.spec.ts
+++ b/src/client/app/frameworks/app.framework/services/app-config.service.spec.ts
@@ -5,12 +5,13 @@ export function main() {
   t.describe('app.framework: AppConfigService', () => {
     
     t.it('SUPPORTED_LANGUAGES', () => {
-      t.e(AppConfigService.SUPPORTED_LANGUAGES.length).toBe(5);
+      t.e(AppConfigService.SUPPORTED_LANGUAGES.length).toBe(6);
       t.e(AppConfigService.SUPPORTED_LANGUAGES[0].code).toBe('en');
       t.e(AppConfigService.SUPPORTED_LANGUAGES[1].code).toBe('es');
-      t.e(AppConfigService.SUPPORTED_LANGUAGES[2].code).toBe('fr');
-      t.e(AppConfigService.SUPPORTED_LANGUAGES[3].code).toBe('ru');
-      t.e(AppConfigService.SUPPORTED_LANGUAGES[4].code).toBe('bg');
+      t.e(AppConfigService.SUPPORTED_LANGUAGES[2].code).toBe('de');
+      t.e(AppConfigService.SUPPORTED_LANGUAGES[3].code).toBe('fr');
+      t.e(AppConfigService.SUPPORTED_LANGUAGES[4].code).toBe('ru');
+      t.e(AppConfigService.SUPPORTED_LANGUAGES[5].code).toBe('bg');
     });
   });
 }

--- a/src/client/app/frameworks/app.framework/services/app-config.service.ts
+++ b/src/client/app/frameworks/app.framework/services/app-config.service.ts
@@ -6,6 +6,7 @@ export class AppConfigService {
   public static SUPPORTED_LANGUAGES: Array<ILang> = [
     { code: 'en', title: 'English' },
     { code: 'es', title: 'Spanish' },
+    { code: 'de', title: 'German' },
     { code: 'fr', title: 'French' },
     { code: 'ru', title: 'Russian' },
     { code: 'bg', title: 'Bulgarian' }

--- a/src/client/app/frameworks/i18n.framework/components/lang-switcher.component.spec.ts
+++ b/src/client/app/frameworks/i18n.framework/components/lang-switcher.component.spec.ts
@@ -14,6 +14,7 @@ import {TEST_MULTILINGUAL_PROVIDERS, TEST_MULTILINGUAL_RESET} from '../testing/i
 const SUPPORTED_LANGUAGES: Array<ILang> = [
   { code: 'en', title: 'English' },
   { code: 'es', title: 'Spanish' },
+  { code: 'de', title: 'German' },
   { code: 'fr', title: 'French' },
   { code: 'ru', title: 'Russian' },
   { code: 'bg', title: 'Bulgarian' }
@@ -61,12 +62,13 @@ export function main() {
             .then(rootTC => {
               rootTC.detectChanges();
               let appDOMEl = rootTC.debugElement.children[0].nativeElement;
-              t.e(getDOM().querySelectorAll(appDOMEl, 'form > select option').length).toBe(5);
+              t.e(getDOM().querySelectorAll(appDOMEl, 'form > select option').length).toBe(6);
               t.e(getDOM().querySelectorAll(appDOMEl, 'form > select option')[0].value).toBe('en');
               t.e(getDOM().querySelectorAll(appDOMEl, 'form > select option')[1].value).toBe('es');
-              t.e(getDOM().querySelectorAll(appDOMEl, 'form > select option')[2].value).toBe('fr');
-              t.e(getDOM().querySelectorAll(appDOMEl, 'form > select option')[3].value).toBe('ru');
-              t.e(getDOM().querySelectorAll(appDOMEl, 'form > select option')[4].value).toBe('bg');
+              t.e(getDOM().querySelectorAll(appDOMEl, 'form > select option')[2].value).toBe('de');
+              t.e(getDOM().querySelectorAll(appDOMEl, 'form > select option')[3].value).toBe('fr');
+              t.e(getDOM().querySelectorAll(appDOMEl, 'form > select option')[4].value).toBe('ru');
+              t.e(getDOM().querySelectorAll(appDOMEl, 'form > select option')[5].value).toBe('bg');
             });
         }))); 
     });

--- a/src/client/assets/i18n/de.json
+++ b/src/client/assets/i18n/de.json
@@ -1,0 +1,11 @@
+{
+  "HOME": "Home",
+  "ABOUT": "Über",
+  "HELLO": "Hallo",
+  "LOVE_TECH": "Ich liebe Technologie!",
+  "ABOUT_ADD": "Willst du mehr? Füge neue Wissenschaftler hinzu!",
+  "ABOUT_REWARD": "Anbei eine Liste großartiger Wissenschaftler ... ",
+  "INPUT_HINT": "Gebe einen neuen Wissenschaftler ein",
+  "ADD_BTN_TEXT": "Hinzufügen",
+  "SUCCESS_MSG": "Deine Angular Installation funktioniert problemlos!"
+}


### PR DESCRIPTION
I added german as supported language.

this time i adapted the tests.

maybe it makes sense to add a short workflow-description to the README.md on how to add a language without breaking the test.

something like this

``` markdown
# framework workflows
## i18n: how to add a language
- src/client/assets/i18n/
  - add NEW_LANGUAGE.json (copy a existing one and adapt the translationstrings)
- src/client/app/frameworks/app.framework/services/app-config.service.spec.ts
  - adapt test
- src/client/app/frameworks/app.framework/services/app-config.service.ts
  - add language to SUPPORTED_LANGUAGES
- src/client/app/frameworks/app.framework/i18n.framework/components/lang-switcher.component.spec.ts
  - adapt test
```
