### PR TITLE
Enable VS Code tasks and launcher (debugger)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ nativescript/app/assets
 desktop
 gulpfile.js
 gulpfile.js.map
+
+
+#VSCode Chrome Debugger Extension (launch.json configuration)
+ChromeDebugger-UserData

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,33 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Launch localhost with sourcemaps",
+			"type": "chrome",
+			"request": "launch",
+			"url": "http://localhost:5555/",
+			"sourceMaps": true,
+            "webRoot": "${workspaceRoot}/dist/dev",
+            "runtimeArgs": [
+                "--remote-debugging-port=9222", //Open in port 9222 (standard chrome debug port)
+                "--user-data-dir=${workspaceRoot}\\ChromeDebugger-UserData\\", //Can be any directory. Makes chrome load in a different directory so that it opens in a new instance.
+                //"--user-data-dir=${env.LOCALAPPDATA}\\Google\\Chrome\\User Data\\", //CHROME DEFAULT
+                "--new-window" //Open in new window
+            ]
+            
+		},
+        {
+            "name": "Launch Electron App",
+            "type": "node",
+            "program": "${workspaceRoot}/dist/dev/main.desktop.js", // important
+            "stopOnEntry": false,
+            "args": [],
+            "cwd": "${workspaceRoot}/dist/dev/",
+            // next line is very important
+            "runtimeExecutable": "${env.APPDATA}/npm/node_modules/electron-prebuilt/dist/electron.exe",
+            "runtimeArgs": [],
+            "env": { }, 
+            "sourceMaps": true
+        }
+	]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,21 +1,20 @@
 {
 	"version": "0.2.0",
 	"configurations": [
-		{
-			"name": "Launch localhost with sourcemaps",
-			"type": "chrome",
-			"request": "launch",
-			"url": "http://localhost:5555/",
-			"sourceMaps": true,
-            "webRoot": "${workspaceRoot}/dist/dev",
-            "runtimeArgs": [
-                "--remote-debugging-port=9222", //Open in port 9222 (standard chrome debug port)
-                "--user-data-dir=${workspaceRoot}\\ChromeDebugger-UserData\\", //Can be any directory. Makes chrome load in a different directory so that it opens in a new instance.
-                //"--user-data-dir=${env.LOCALAPPDATA}\\Google\\Chrome\\User Data\\", //CHROME DEFAULT
-                "--new-window" //Open in new window
-            ]
-            
-		},
+	{
+		"name": "Launch localhost with sourcemaps",
+		"type": "chrome",
+		"request": "launch",
+		"url": "http://localhost:5555/",
+		"sourceMaps": true,
+		"webRoot": "${workspaceRoot}/dist/dev",
+		"runtimeArgs": [
+			"--remote-debugging-port=9222", //Open in port 9222 (standard chrome debug port)
+			"--user-data-dir=${workspaceRoot}\\ChromeDebugger-UserData\\", //Can be any directory. Makes chrome load in a different directory so that it opens in a new instance.
+			//"--user-data-dir=${env.LOCALAPPDATA}\\Google\\Chrome\\User Data\\", //CHROME DEFAULT
+			"--new-window" //Open in new window
+		]
+	},
         {
             "name": "Launch Electron App",
             "type": "node",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,94 @@
+{
+    "version": "0.1.0",
+    "command": "npm",
+    "isShellCommand": true,
+    "showOutput": "always",
+    "args": ["run"],
+    "echoCommand": true,
+    "tasks": [
+        {
+            "taskName": "start",
+            "isBuildCommand": true,
+            "showOutput": "always",
+            "isWatching": true,
+            "isTestCommand": false
+        },
+        {
+            "taskName": "start.desktop",
+            "isBuildCommand": false,
+            "showOutput": "always",
+            "isWatching": true,
+            "isTestCommand": false
+        },
+        {
+            "taskName": "start.desktop.windows",
+            "isBuildCommand": false,
+            "showOutput": "always",
+            "isWatching": true,
+            "isTestCommand": false
+        },
+        {
+            "taskName": "start.livesync.desktop",
+            "isBuildCommand": false,
+            "showOutput": "always",
+            "isWatching": true,
+            "isTestCommand": false
+        },
+        {
+            "taskName": "start.livesync.desktop.windows",
+            "isBuildCommand": false,
+            "showOutput": "always",
+            "isWatching": true,
+            "isTestCommand": false
+        },
+        {
+            "taskName": "start.ios",
+            "isBuildCommand": false,
+            "showOutput": "always",
+            "isWatching": true,
+            "isTestCommand": false
+        },
+        {
+            "taskName": "start.livesync.ios",
+            "isBuildCommand": false,
+            "showOutput": "always",
+            "isWatching": true,
+            "isTestCommand": false
+        },
+        {
+            "taskName": "start.livesync.ios.device",
+            "isBuildCommand": false,
+            "showOutput": "always",
+            "isWatching": true,
+            "isTestCommand": false
+        },
+        {
+            "taskName": "start.android",
+            "isBuildCommand": false,
+            "showOutput": "always",
+            "isWatching": true,
+            "isTestCommand": false
+        },
+        {
+            "taskName": "start.livesync.android",
+            "isBuildCommand": false,
+            "showOutput": "always",
+            "isWatching": true,
+            "isTestCommand": false
+        },
+        {
+            "taskName": "start.livesync.android.device",
+            "isBuildCommand": false,
+            "showOutput": "always",
+            "isWatching": true,
+            "isTestCommand": false
+        },
+        {
+            "taskName": "test",
+            "isBuildCommand": false,
+            "showOutput": "always",
+            "isWatching": true,
+            "isTestCommand": true
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,6 +7,13 @@
     "echoCommand": true,
     "tasks": [
         {
+            "taskName": "reinstall",
+            "isBuildCommand": true,
+            "showOutput": "always",
+            "isWatching": true,
+            "isTestCommand": false
+        },
+        {
             "taskName": "start",
             "isBuildCommand": true,
             "showOutput": "always",

--- a/tools/tasks/seed/build.js.dev.ts
+++ b/tools/tasks/seed/build.js.dev.ts
@@ -31,7 +31,7 @@ export = () => {
     .pipe(plugins.typescript(tsProject));
 
   return result.js
-    .pipe(plugins.sourcemaps.write('.', {includeContent: false, sourceRoot: '../../src/client'}))
+    .pipe(plugins.sourcemaps.write('.', {includeContent: true, sourceRoot: '../../src/client'}))
     .pipe(plugins.template(templateLocals()))
     .pipe(gulp.dest(APP_DEST));
 };

--- a/tools/tasks/seed/build.js.dev.ts
+++ b/tools/tasks/seed/build.js.dev.ts
@@ -31,7 +31,7 @@ export = () => {
     .pipe(plugins.typescript(tsProject));
 
   return result.js
-    .pipe(plugins.sourcemaps.write('.', {includeContent: true, sourceRoot: '../../src/client'}))
     .pipe(plugins.template(templateLocals()))
+    .pipe(plugins.sourcemaps.write('.', {includeContent: true, sourceRoot: '../../src/client'}))
     .pipe(gulp.dest(APP_DEST));
 };

--- a/tools/tasks/seed/build.js.dev.ts
+++ b/tools/tasks/seed/build.js.dev.ts
@@ -31,7 +31,7 @@ export = () => {
     .pipe(plugins.typescript(tsProject));
 
   return result.js
-    .pipe(plugins.sourcemaps.write())
+    .pipe(plugins.sourcemaps.write('.', {includeContent: false, sourceRoot: '../../src/client'}))
     .pipe(plugins.template(templateLocals()))
     .pipe(gulp.dest(APP_DEST));
 };


### PR DESCRIPTION
Have create some configurations for the VSCode editor with the possibility to run the npm tasks (scripts) and launch the debugger.

The change in the task "build.js.dev.ts" allow Chrome Debugger extension (from VSCode) to read the sourcemaps generated in another file (actually doesn't support inline sourcemaps).
