### PR TITLE
Component CSS for {N} is now moved to tns.css-files

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ npm install -g nativescript
 
 You can make changes to files in `src/client` or `nativescript` folders. A symbolic link exists between the web `src/client` and the `nativescript` folder so changes in either location are mirrored because they are the same directory inside.
 
-Create `.tns.html` NativeScript view files for every web component view file you have. You will see an example of the `app.component.html` as a [NativeScript view file here](https://github.com/NathanWalker/angular2-seed-advanced/blob/master/src/client/app/components/app/app.component.tns.html).
+Create `.tns.html` and `.tns.css` NativeScript view files for every web component view file you have. You will see an example of the `app.component.html` as a [NativeScript view file here](https://github.com/NathanWalker/angular2-seed-advanced/blob/master/src/client/app/components/app/app.component.tns.html).
 
 #### Run
 

--- a/nativescript/app/app.css
+++ b/nativescript/app/app.css
@@ -3,19 +3,6 @@ ActionBar {
   color:white;
 }
 
-.nav {
-  padding:10;
-}
-
-.nav button {
-  margin:0 20 0 0;
-  color: #777;
-}
-
-.nav button.active {
-  color: #106CC8;
-}
-
 SegmentedBar {
   color: #106CC8;
   margin: 0 10 0 10;
@@ -73,31 +60,10 @@ TextField {
     background-color: #808080
 }
 
-.heading {
-  margin:10 0 0 0;
-  font-size: 24;
-  color:#106CC8;
-}
-
-.feature-list label {
-  font-size:16;
-  color:#555;
-  margin:0 0 5 0;
-}
-.list-item {
-  padding:5;
-}
 .odd {
     background-color: #efefef;
 }
 
 .even {
     background-color: #fff;
-}
-
-.love-tech {
-  font-size:28;
-  font-weight: bold;
-  color: purple;
-  margin:8 0 8 0;
 }

--- a/src/client/app/components/about/about.component.tns.css
+++ b/src/client/app/components/about/about.component.tns.css
@@ -1,0 +1,11 @@
+.feature-list label {
+  font-size: 16;
+  color: #555;
+  margin: 0 0 5 0;
+}
+
+.heading {
+  margin: 10 0 0 0;
+  font-size: 24;
+  color: #106CC8;
+}

--- a/src/client/app/components/app/navbar.component.tns.css
+++ b/src/client/app/components/app/navbar.component.tns.css
@@ -1,0 +1,12 @@
+.nav {
+  padding: 10;
+}
+
+.nav button {
+  margin: 0 20 0 0;
+  color: #777;
+}
+
+.nav button.active {
+  color: #106CC8;
+}

--- a/src/client/app/components/home/home.component.tns.css
+++ b/src/client/app/components/home/home.component.tns.css
@@ -1,0 +1,10 @@
+.love-tech {
+  font-size: 28;
+  font-weight: bold;
+  color: purple;
+  margin: 8 0 8 0;
+}
+
+.list-item {
+  padding: 5;
+}

--- a/src/client/app/frameworks/core/decorators/utils.ts
+++ b/src/client/app/frameworks/core/decorators/utils.ts
@@ -20,45 +20,50 @@ export class DecoratorUtils {
     // default directives
     let DIRECTIVES: any[] = [];
     // default pipes
-    let PIPES: any[] = [TranslatePipe];   
-    
+    let PIPES: any[] = [TranslatePipe];
+
     // custom decorator options
     if (customDecoratorMetadata) {
       if (customDecoratorMetadata.directives) {
-        DIRECTIVES.push(...customDecoratorMetadata.directives); 
+        DIRECTIVES.push(...customDecoratorMetadata.directives);
       }
       if (customDecoratorMetadata.pipes) {
-        PIPES.push(...customDecoratorMetadata.pipes); 
+        PIPES.push(...customDecoratorMetadata.pipes);
       }
     }
-    
+
     if (metadata.templateUrl) {
       // correct view for platform target
       metadata.templateUrl = ViewBrokerService.TEMPLATE_URL(metadata.templateUrl);
     }
-    
+
+    if (metadata.styleUrls) {
+      // correct view for platform target
+      metadata.styleUrls = ViewBrokerService.STYLE_URLS(metadata.styleUrls);
+    }
+
     metadata.directives = metadata.directives ? metadata.directives.concat(DIRECTIVES) : DIRECTIVES;
     metadata.pipes = metadata.pipes ? metadata.pipes.concat(PIPES) : PIPES;
-    
+
     if (metadata.changeDetection) {
       metadata.changeDetection = metadata.changeDetection;
     } else {
       // default OnPush
       metadata.changeDetection = ChangeDetectionStrategy.OnPush;
     }
-    
+
     if (metadata.encapsulation) {
       metadata.encapsulation = metadata.encapsulation;
     }
-    
-    // initialize anything 
+
+    // initialize anything
     if (metadata.init) {
       metadata.init();
-    }   
+    }
 
     return metadata;
   }
-  
+
   public static annotateComponent(cls: any, metadata: any = {}, customDecoratorMetadata?: any) {
     let annotations = _reflect.getMetadata('annotations', cls) || [];
     annotations.push(new Component(DecoratorUtils.getMetadata(metadata, customDecoratorMetadata)));

--- a/src/client/app/frameworks/core/services/view-broker.service.ts
+++ b/src/client/app/frameworks/core/services/view-broker.service.ts
@@ -1,14 +1,26 @@
 import {CoreConfigService} from './core-config.service';
 
 export class ViewBrokerService {
-  
-  public static TEMPLATE_URL(path: string): string {  
+
+  public static TEMPLATE_URL(path: string): string {
     if (CoreConfigService.IS_MOBILE_NATIVE()) {
       let paths = path.split('.');
       paths.splice(-1);
       return `${paths.join('.')}.tns.html`;
     } else {
       return path;
-    } 
+    }
+  }
+
+  public static STYLE_URLS(paths: string[]): string[] {
+    if (CoreConfigService.IS_MOBILE_NATIVE()) {
+      return paths.map((path) => {
+        let parts = path.split('.');
+        parts.splice(-1);
+        return `${parts.join('.')}.tns.css`;
+      });
+    } else {
+      return paths;
+    }
   }
 }


### PR DESCRIPTION
It's very nice that styleUrls are no longer stripped:
https://github.com/NathanWalker/angular2-seed-advanced/issues/111#issuecomment-225343291

But I'd like to keep CSS for {N} separated from CSS for web, so I've added ViewBrokerService.STYLE_URLS(paths: string[]) {...}
