### PR TITLE
RC.5 TestBed and Test Import Updates

### DIFF
--- a/nativescript/package.json
+++ b/nativescript/package.json
@@ -5,7 +5,7 @@
     "nativescript": {
         "id": "com.yourdomain.appname",
         "tns-ios": {
-            "version": "2.2.0"
+            "version": "2.2.1"
         },
         "tns-android": {
             "version": "2.2.0"

--- a/src/client/app/components/about/about.component.spec.ts
+++ b/src/client/app/components/about/about.component.spec.ts
@@ -1,4 +1,4 @@
-import {TestComponentBuilder} from '@angular/compiler/testing';
+import {TestComponentBuilder} from '@angular/core/testing';
 import {Component} from '@angular/core';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 import {disableDeprecatedForms, provideForms} from '@angular/forms';

--- a/src/client/app/components/app/app.component.spec.ts
+++ b/src/client/app/components/app/app.component.spec.ts
@@ -1,4 +1,4 @@
-import {TestComponentBuilder} from '@angular/compiler/testing';
+import {TestComponentBuilder} from '@angular/core/testing';
 import {Component} from '@angular/core';
 import {disableDeprecatedForms, provideForms} from '@angular/forms';
 import {RouterConfig} from '@angular/router';

--- a/src/client/app/frameworks/core/directives/platform.directive.spec.ts
+++ b/src/client/app/frameworks/core/directives/platform.directive.spec.ts
@@ -1,4 +1,4 @@
-import {TestComponentBuilder} from '@angular/compiler/testing';
+import {TestComponentBuilder} from '@angular/core/testing';
 import {Component, provide} from '@angular/core';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 

--- a/src/client/app/frameworks/core/services/log.service.spec.ts
+++ b/src/client/app/frameworks/core/services/log.service.spec.ts
@@ -1,4 +1,5 @@
 import {provide} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
 
 import {t} from '../../test/index';
 import {Config, ConsoleService, LogService} from '../index';
@@ -10,7 +11,7 @@ const providers: any[] = [
 
 export function main() {
   t.describe('core: LogService', () => {
-    
+
     t.be(() => {
       // ensure statics are in default state
       Config.RESET();
@@ -20,18 +21,20 @@ export function main() {
       t.spyOn(console, 'warn');
       t.spyOn(console, 'info');
     });
-    
+
     t.describe('api', () => {
-      
-      t.bep(() => providers);
-      
+
+      TestBed.configureTestingModule({
+        providers: providers
+      });
+
       t.it('sanity', t.inject([LogService], (log: LogService) => {
         t.e(log.debug).toBeDefined();
         t.e(log.error).toBeDefined();
         t.e(log.warn).toBeDefined();
         t.e(log.info).toBeDefined();
       }));
-      
+
       t.it('should not log anything by default', t.inject([LogService], (log: LogService) => {
         log.debug('debug');
         t.e(console.log).not.toHaveBeenCalledWith('debug');
@@ -45,16 +48,18 @@ export function main() {
     });
 
     t.describe('debug levels', () => {
-      
+
       t.be(() => {
         Config.RESET();
       });
-      
-      t.bep(() => providers);
-      
+
+      TestBed.configureTestingModule({
+        providers: providers
+      });
+
       t.it('LEVEL_4: everything', t.inject([LogService], (log: LogService) => {
         Config.DEBUG.LEVEL_4 = true;
-        
+
         log.debug('debug');
         t.e(console.log).toHaveBeenCalledWith('debug');
         log.error('error');
@@ -64,7 +69,7 @@ export function main() {
         log.info('info');
         t.e(console.info).toHaveBeenCalledWith('info');
       }));
-      
+
       t.it('LEVEL_3: error only', t.inject([LogService], (log: LogService) => {
         Config.DEBUG.LEVEL_3 = true;
 
@@ -76,7 +81,7 @@ export function main() {
         t.e(console.warn).not.toHaveBeenCalledWith('warn');
         log.info('info');
         t.e(console.info).not.toHaveBeenCalledWith('info');
-        
+
         // always overrides lower levels and allows them to come through
         Config.DEBUG.LEVEL_4 = true;
 
@@ -89,7 +94,7 @@ export function main() {
         log.info('info w/level_4');
         t.e(console.info).toHaveBeenCalledWith('info w/level_4');
       }));
-      
+
       t.it('LEVEL_2: warn only', t.inject([LogService], (log: LogService) => {
         Config.DEBUG.LEVEL_2 = true;
 
@@ -102,7 +107,7 @@ export function main() {
         log.info('info');
         t.e(console.info).not.toHaveBeenCalledWith('info');
       }));
-      
+
       t.it('LEVEL_1: info only', t.inject([LogService], (log: LogService) => {
         Config.DEBUG.LEVEL_1 = true;
 

--- a/src/client/app/frameworks/i18n/components/lang-switcher.component.spec.ts
+++ b/src/client/app/frameworks/i18n/components/lang-switcher.component.spec.ts
@@ -1,4 +1,4 @@
-import {TestComponentBuilder} from '@angular/compiler/testing';
+import {TestComponentBuilder, TestBed} from '@angular/core/testing';
 import {Component} from '@angular/core';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 
@@ -22,13 +22,15 @@ const SUPPORTED_LANGUAGES: Array<ILang> = [
 export function main() {
   t.describe('i18n:', () => {
     t.describe('@Component: LangSwitcherComponent', () => {
-      t.bep(() => [
-        TEST_CORE_PROVIDERS(),
-        TEST_HTTP_PROVIDERS(),
-        TEST_ROUTER_PROVIDERS(),
-        TEST_MULTILINGUAL_PROVIDERS(),
-        provideStore({ i18n: multilingualReducer })
-      ]);
+      TestBed.configureTestingModule({
+        providers: [
+          TEST_CORE_PROVIDERS(),
+          TEST_HTTP_PROVIDERS(),
+          TEST_ROUTER_PROVIDERS(),
+          TEST_MULTILINGUAL_PROVIDERS(),
+          provideStore({ i18n: multilingualReducer })
+        ]
+      });
 
       t.it('should work',
         t.async(t.inject([TestComponentBuilder], (tcb: TestComponentBuilder) => {
@@ -44,13 +46,15 @@ export function main() {
 
     t.describe('@Component: LangSwitcherComponent with multiple languages', () => {
       t.be(() => MultilingualService.SUPPORTED_LANGUAGES = SUPPORTED_LANGUAGES);
-      t.bep(() => [
-        TEST_CORE_PROVIDERS(),
-        TEST_HTTP_PROVIDERS(),
-        TEST_ROUTER_PROVIDERS(),
-        TEST_MULTILINGUAL_PROVIDERS(),
-        provideStore({ i18n: multilingualReducer })
-      ]);
+      TestBed.configureTestingModule({
+        providers: [
+          TEST_CORE_PROVIDERS(),
+          TEST_HTTP_PROVIDERS(),
+          TEST_ROUTER_PROVIDERS(),
+          TEST_MULTILINGUAL_PROVIDERS(),
+          provideStore({ i18n: multilingualReducer })
+        ]
+      });
 
       // ensure statics are reset when the test had modified statics in a beforeEach (be) or beforeEachProvider (bep)
       t.ae(() => TEST_MULTILINGUAL_RESET());

--- a/src/client/app/frameworks/i18n/services/multilingual.service.spec.ts
+++ b/src/client/app/frameworks/i18n/services/multilingual.service.spec.ts
@@ -1,6 +1,6 @@
+import {TestBed} from '@angular/core/testing';
 // libs
 import {provideStore, Store} from '@ngrx/store';
-
 import {t} from '../../test/index';
 // import {TEST_CORE_PROVIDERS, TEST_HTTP_PROVIDERS, TEST_ROUTER_PROVIDERS, WindowMockFrench} from '../../core/testing/index';
 import {TEST_CORE_PROVIDERS, TEST_HTTP_PROVIDERS, TEST_ROUTER_PROVIDERS} from '../../core/testing/index';
@@ -12,13 +12,15 @@ import {MultilingualService, MultilingualStateI, multilingualReducer} from '../i
 export function main() {
   t.describe('i18n:', () => {
     t.describe('MultilingualService', () => {
-      t.bep(() => [
-        TEST_CORE_PROVIDERS(),
-        TEST_HTTP_PROVIDERS(),
-        TEST_ROUTER_PROVIDERS(),
-        TEST_MULTILINGUAL_PROVIDERS(),
-        provideStore({ i18n: multilingualReducer })
-      ]);
+      TestBed.configureTestingModule({
+        providers: [
+          TEST_CORE_PROVIDERS(),
+          TEST_HTTP_PROVIDERS(),
+          TEST_ROUTER_PROVIDERS(),
+          TEST_MULTILINGUAL_PROVIDERS(),
+          provideStore({ i18n: multilingualReducer })
+        ]
+      });
       t.it('should at a minimum support english', () => {
         t.e(MultilingualService.SUPPORTED_LANGUAGES.length).toBe(1);
         t.e(MultilingualService.SUPPORTED_LANGUAGES[0].code).toBe('en');
@@ -53,8 +55,8 @@ export function main() {
     //     provideStore({ i18n: multilingualReducer })
     //   ]);
     //   // ensure statics are reset when the test had modified statics in a beforeEach (be) or beforeEachProvider (bep)
-    //   t.ae(() => TEST_MULTILINGUAL_RESET());  
-      
+    //   t.ae(() => TEST_MULTILINGUAL_RESET());
+
     //   t.it('should now support french by default', t.inject([MultilingualService, Store, WindowService], (multilang: MultilingualService, store: Store<any>, win: WindowService) => {
     //     t.e(MultilingualService.SUPPORTED_LANGUAGES.length).toBe(2);
     //     t.e(MultilingualService.SUPPORTED_LANGUAGES[0].code).toBe('en');
@@ -64,8 +66,8 @@ export function main() {
     //     store.select('i18n').subscribe((i18n: MultilingualStateI) => {
     //       t.e(i18n.lang).toBe('fr');
     //     });
-    //   }));     
-    
+    //   }));
+
     // });
   });
 


### PR DESCRIPTION
Mainly just changing out the new import locations, as well as replacing the shorthand of `bep` with the `TestBed` implementation.

Also updated the tns-ios version to use the updated minor release.

I believe nativescript-angular is still not supporting rc.5, correct? Because I could not successfully get past an animation driver conflict, when attempting to update the NS app to rc.5 (not part of this PR).

(Duplicated PR because I accidentally tried to merge into master...haha)
