### PR TITLE
Fix for #292, NPM run clean fails with TSError: ⨯ Unable to compile TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "license": "MIT",
   "devDependencies": {
     "@angular/compiler-cli": "^0.6.1",
-    "@angular/platform-server": "^2.0.0-rc.7",
+    "@angular/platform-server": "2.0.0",
     "@angular/tsc-wrapped": "^0.3.0",
     "async": "^2.0.0",
     "autoprefixer": "^6.3.7",

--- a/tools/tasks/seed/clean.all.src.js.ts
+++ b/tools/tasks/seed/clean.all.src.js.ts
@@ -4,14 +4,14 @@ import * as util from 'gulp-util';
 import * as rimraf from 'rimraf';
 import { join } from 'path';
 
-import { APP_SRC } from '../../config';
+import Config from '../../config';
 
 /**
  * Executes the build process, deleting all JavaScript and Source Map files (which were transpiled from the TypeScript sources) with in
  * the `src/client` directory.
  */
 export = (done: any) => {
-  deleteAndWalk(APP_SRC);
+  deleteAndWalk(Config.APP_SRC);
   done();
 };
 


### PR DESCRIPTION
This resolves the compilation error and updates the @angular/platform-server to version 2.0.0
