### PR TITLE
feat: PageWrapService and PageComponent-decorator

### DIFF
--- a/nativescript/app/app.ts
+++ b/nativescript/app/app.ts
@@ -6,6 +6,8 @@ import { NativeScriptModule, platformNativeScriptDynamic, onAfterLivesync, onBef
  * Seed provided configuration options
  */
 import { Config } from './app/frameworks/core/index';
+import { TNSPageWrapService } from './shared/core/services/ns-pagewrap.service';
+Config.PageWrapService = <any>TNSPageWrapService;
 
 // (required) platform target (allows component decorators to use the right view template)
 Config.PLATFORM_TARGET = Config.PLATFORMS.MOBILE_NATIVE;

--- a/nativescript/app/shared/core/services/ns-pagewrap.service.ts
+++ b/nativescript/app/shared/core/services/ns-pagewrap.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@angular/core';
+import { Page } from 'ui/page';
+
+// app
+import { PageWrapService } from '../../../app/frameworks/core/index';
+
+@Injectable()
+export class TNSPageWrapService extends PageWrapService {
+  constructor(public page: Page) {
+    super();
+  }
+}

--- a/nativescript/package.json
+++ b/nativescript/package.json
@@ -8,7 +8,7 @@
       "version": "2.2.1"
     },
     "tns-android": {
-      "version": "2.2.0"
+      "version": "2.3.0"
     }
   },
   "scripts": {

--- a/src/client/app/components/about/about.component.ts
+++ b/src/client/app/components/about/about.component.ts
@@ -1,11 +1,15 @@
-import {BaseComponent} from '../../frameworks/core/index';
+import {PageComponent, PageWrapService} from '../../frameworks/core/index';
 
-@BaseComponent({
+@PageComponent({
   moduleId: module.id,
   selector: 'sd-about',
   templateUrl: 'about.component.html',
   styleUrls: ['about.component.css']
 })
 export class AboutComponent  {
-  
+  constructor(public pagewrap: PageWrapService) {
+    if (pagewrap.page) {
+      pagewrap.page.actionBarHidden = true;
+    }
+  }
 }

--- a/src/client/app/components/home/home.component.ts
+++ b/src/client/app/components/home/home.component.ts
@@ -2,10 +2,10 @@
 import { Store } from '@ngrx/store';
 
 // app
-import { BaseComponent, RouterExtensions } from '../../frameworks/core/index';
+import { PageComponent, RouterExtensions } from '../../frameworks/core/index';
 import { NameListService } from '../../frameworks/sample/index';
 
-@BaseComponent({
+@PageComponent({
   moduleId: module.id,
   selector: 'sd-home',
   templateUrl: 'home.component.html',

--- a/src/client/app/frameworks/core/decorators/page.component.ts
+++ b/src/client/app/frameworks/core/decorators/page.component.ts
@@ -1,0 +1,13 @@
+import { DecoratorUtils } from './utils';
+import { Config } from '../utils/config';
+import { PageWrapService } from '../services/pagewrap.service';
+
+export function PageComponent(metadata: any = {}) {
+  return function(cls: any) {
+    return DecoratorUtils.annotateComponent(cls, metadata, {
+      providers: [
+        { provide: PageWrapService, useClass: Config.PageWrapService }
+      ]
+    });
+  };
+}

--- a/src/client/app/frameworks/core/decorators/utils.ts
+++ b/src/client/app/frameworks/core/decorators/utils.ts
@@ -11,15 +11,14 @@ export class DecoratorUtils {
   public static getMetadata(metadata: any = {}, customDecoratorMetadata?: any) {
     /**
      * The following allows default component metadata to be configured
-     * For instance, here we make `TranslatePipe` available for all our components
      */
     // default directives
-    let DIRECTIVES: any[] = [];
+    let PROVIDERS: any[] = [];
 
     // custom decorator options
     if (customDecoratorMetadata) {
-      if (customDecoratorMetadata.directives) {
-        DIRECTIVES.push(...customDecoratorMetadata.directives);
+      if (customDecoratorMetadata.providers) {
+        PROVIDERS.push(...customDecoratorMetadata.providers);
       }
     }
 
@@ -33,7 +32,7 @@ export class DecoratorUtils {
       metadata.styleUrls = ViewBroker.STYLE_URLS(metadata.styleUrls);
     }
 
-    metadata.directives = metadata.directives ? metadata.directives.concat(DIRECTIVES) : DIRECTIVES;
+    metadata.providers = metadata.providers ? metadata.providers.concat(PROVIDERS) : PROVIDERS;
 
     if (metadata.changeDetection) {
       metadata.changeDetection = metadata.changeDetection;

--- a/src/client/app/frameworks/core/index.ts
+++ b/src/client/app/frameworks/core/index.ts
@@ -5,6 +5,7 @@ export * from './utils/view-broker';
 
 // decorators
 export * from './decorators/base.component';
+export * from './decorators/page.component';
 
 // interfaces
 export * from './interfaces/iconsole';
@@ -13,6 +14,7 @@ export * from './interfaces/ilang';
 
 // services
 export * from './services/console.service';
+export * from './services/pagewrap.service';
 export * from './services/log.service';
 export * from './services/window.service';
 export * from './services/router-extensions';

--- a/src/client/app/frameworks/core/services/pagewrap.service.ts
+++ b/src/client/app/frameworks/core/services/pagewrap.service.ts
@@ -1,0 +1,6 @@
+import {Injectable} from '@angular/core';
+
+@Injectable()
+export class PageWrapService {
+  page: any = null;
+}

--- a/src/client/app/frameworks/core/utils/config.ts
+++ b/src/client/app/frameworks/core/utils/config.ts
@@ -12,7 +12,11 @@ interface IPlatforms {
   DESKTOP: string;
 }
 
+import { PageWrapService } from '../services/pagewrap.service';
+
 export class Config {
+
+  public static PageWrapService = PageWrapService;
 
   public static DEBUG: any = {
     LEVEL_1: false, // .info only


### PR DESCRIPTION
- Adds the `PageComponent` Decoraator that injects the new class PageWrapService
- Adds `PageWrapService` and `TNSPageWrapService` for getting the page-object
  for the current page, which is injected by Angular Native's `page-router-outlet`

I've removed the `customDecoratorMetadata.directives` from `DecoratorUtils` since after `NgModule` was introducted the `@Component`-decorator no longer takes an `directives`-array.
I've replaced it with an `providers`-array, since `NgModule` makes providers implicitly singleton and we need the current page-object created and injected by Angular Native's `page-router-outlet`.

I'm not sure about adding the PageWrapService to the `Config`-class and replacing it at boottime in {N}, but I couldn't figure out a better way to do it.
