### PR TITLE
Automatic desktop dependencies

### DIFF
--- a/tools/tasks/project/desktop.libs.ts
+++ b/tools/tasks/project/desktop.libs.ts
@@ -12,7 +12,7 @@ export = () => {
     'node_modules/@ngrx/**/*'
   ];
 
-  src.push(...Config.DEPENDENCIES.map(x => relative(Config.PROJECT_ROOT, x.src)));
+  src.push(...Config.NPM_DEPENDENCIES.map(x => relative(Config.PROJECT_ROOT, x.src)));
 
   return gulp.src(src, { base: 'node_modules' })
     .pipe(gulp.dest(join(Config.APP_DEST + '/node_modules')));

--- a/tools/tasks/project/desktop.libs.ts
+++ b/tools/tasks/project/desktop.libs.ts
@@ -1,19 +1,19 @@
 import * as gulp from 'gulp';
-import {join} from 'path';
+import {relative, join} from 'path';
 import Config from '../../config';
 
 export = () => {
   let src = [
-    'node_modules/systemjs/**/*',
-    'node_modules/core-js/**/*',
     'node_modules/@angular/**/*',
     'node_modules/rxjs/**/*',
     'node_modules/angulartics2/**/*',
     'node_modules/lodash/**/*',
     'node_modules/ng2-translate/**/*',
-    'node_modules/@ngrx/**/*',
-    'node_modules/zone.js/**/*'
+    'node_modules/@ngrx/**/*'
   ];
+
+  src.push(...Config.DEPENDENCIES.map(x => relative(Config.PROJECT_ROOT, x.src)));
+
   return gulp.src(src, { base: 'node_modules' })
     .pipe(gulp.dest(join(Config.APP_DEST + '/node_modules')));
 };


### PR DESCRIPTION
A PR following #243 to automate the desktop.libs.ts functionality of copying dependencies for the desktop. The changed code looks at the DEPENDENCIES configuration value and copies all of the dependencies defined in there, so you don't have to define them twice. This means all NPM_DEPENDENCIES and APP_ASSETS defined in project.config.ts will be copied to the node_modules folder for the desktop automatically.

Question: APP_ASSETS are also copied to node_modules, because that's the only destination specified in desktop.libs.ts. I did not do extensive testing to see how that plays out.
