### PR TITLE
Speed compiles with gulp newer

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "gulp-inject": "^4.1.0",
     "gulp-inline-ng2-template": "^3.0.1",
     "gulp-load-plugins": "^1.2.4",
+    "gulp-newer": "^1.2.0",
     "gulp-plumber": "~1.1.0",
     "gulp-postcss": "^6.1.1",
     "gulp-progeny": "^0.3.1",

--- a/tools/env/env-config.interface.ts
+++ b/tools/env/env-config.interface.ts
@@ -1,2 +1,2 @@
-export { EnvConfig } from '../../src/client/app/shared/config/env.config';
+export { EnvConfig } from '../../src/client/app/frameworks/core/utils/config';
 

--- a/tools/tasks/project/desktop.build.ts
+++ b/tools/tasks/project/desktop.build.ts
@@ -1,5 +1,6 @@
 import * as gulp from 'gulp';
 import { join } from 'path';
+var newer = require('gulp-newer');
 
 import Config from '../../config';
 
@@ -8,5 +9,9 @@ export = () => {
     join(Config.APP_SRC, 'package.json')
   ];
   return gulp.src(src)
+    // .pipe(newer({
+    //   dest: Config.APP_DEST, 
+    //   map: function(path: String) { return path.replace(".ts", ".js").replace(".sccs", ".css"); }
+    // }))
     .pipe(gulp.dest(Config.APP_DEST));
 };

--- a/tools/tasks/project/desktop.libs.ts
+++ b/tools/tasks/project/desktop.libs.ts
@@ -1,6 +1,7 @@
 import * as gulp from 'gulp';
 import { relative, join } from 'path';
 import Config from '../../config';
+var newer = require('gulp-newer');
 
 export = () => {
   let src = [
@@ -15,5 +16,9 @@ export = () => {
   src.push(...Config.NPM_DEPENDENCIES.map(x => relative(Config.PROJECT_ROOT, x.src)));
 
   return gulp.src(src, { base: 'node_modules' })
+    // .pipe(newer({
+    //   dest: join(Config.APP_DEST + '/node_modules'), 
+    //   map: function(path: String) { return path.replace(".ts", ".js").replace(".sccs", ".css"); }
+    // }))
     .pipe(gulp.dest(join(Config.APP_DEST + '/node_modules')));
 };

--- a/tools/tasks/seed/build.assets.dev.ts
+++ b/tools/tasks/seed/build.assets.dev.ts
@@ -1,5 +1,6 @@
 import * as gulp from 'gulp';
 import { join } from 'path';
+var newer = require('gulp-newer');
 
 import Config from '../../config';
 
@@ -15,5 +16,9 @@ export = () => {
   ].concat(Config.TEMP_FILES.map((p) => { return '!' + p; }));
 
   return gulp.src(paths)
+    // .pipe(newer({
+    //   dest: Config.APP_DEST, 
+    //   map: function(path: String) { return path.replace(".ts", ".js").replace(".sccs", ".css"); }
+    // }))
     .pipe(gulp.dest(Config.APP_DEST));
 };

--- a/tools/tasks/seed/build.html_css.ts
+++ b/tools/tasks/seed/build.html_css.ts
@@ -5,6 +5,7 @@ import * as gulpLoadPlugins from 'gulp-load-plugins';
 import * as merge from 'merge-stream';
 import * as util from 'gulp-util';
 import { join } from 'path';
+var newer = require('gulp-newer');
 
 import Config from '../../config';
 
@@ -38,6 +39,7 @@ if (isProd) {
  */
 function prepareTemplates() {
   return gulp.src(join(Config.APP_SRC, '**', '*.html'))
+    .pipe(newer({ dest: Config.TMP_DIR }))
     .pipe(gulp.dest(Config.TMP_DIR));
 }
 
@@ -60,6 +62,10 @@ function processComponentScss() {
     .pipe(plugins.postcss(processors))
     .on('error', reportPostCssError)
     .pipe(plugins.sourcemaps.write(isProd ? '.' : ''))
+    .pipe(newer({
+      dest: isProd ? Config.TMP_DIR : Config.APP_DEST, 
+      map: function(path: String) { return path.replace(".ts", ".js").replace(".sccs", ".css"); }
+    }))
     .pipe(gulp.dest(isProd ? Config.TMP_DIR : Config.APP_DEST));
 }
 
@@ -75,6 +81,10 @@ function processComponentCss() {
     .pipe(isProd ? plugins.cached('process-component-css') : plugins.util.noop())
     .pipe(plugins.postcss(processors))
     .on('error', reportPostCssError)
+    .pipe(newer({
+      dest: isProd ? Config.TMP_DIR : Config.APP_DEST, 
+      map: function(path: String) { return path.replace(".ts", ".js").replace(".sccs", ".css"); }
+    }))
     .pipe(gulp.dest(isProd ? Config.TMP_DIR : Config.APP_DEST));
 }
 
@@ -95,6 +105,10 @@ function processAllExternalStylesheets() {
     .pipe(plugins.postcss(processors))
     .on('error', reportPostCssError)
     .pipe(isProd ? cleanCss() : plugins.util.noop())
+    .pipe(newer({
+      dest: Config.CSS_DEST, 
+      map: function(path: String) { return path.replace(".ts", ".js").replace(".sccs", ".css"); }
+    }))
     .pipe(gulp.dest(Config.CSS_DEST));
 }
 
@@ -141,6 +155,10 @@ function processExternalCss() {
     .pipe(isProd ? plugins.concatCss(gulpConcatCssConfig.targetFile, gulpConcatCssConfig.options) : plugins.util.noop())
     .on('error', reportPostCssError)
     .pipe(isProd ? cleanCss() : plugins.util.noop())
+     .pipe(newer({
+       dest: Config.CSS_DEST, 
+       map: function(path: String) { return path.replace(".ts", ".js").replace(".sccs", ".css"); }
+     }))
     .pipe(gulp.dest(Config.CSS_DEST));
 }
 

--- a/tools/tasks/seed/build.index.dev.ts
+++ b/tools/tasks/seed/build.index.dev.ts
@@ -5,6 +5,7 @@ import * as slash from 'slash';
 
 import Config from '../../config';
 import { templateLocals } from '../../utils';
+var newer = require('gulp-newer');
 
 const plugins = <any>gulpLoadPlugins();
 
@@ -18,6 +19,7 @@ export = () => {
     .pipe(inject('libs'))
     .pipe(inject())
     .pipe(plugins.template(templateLocals()))
+    // .pipe(newer(Config.APP_DEST))
     .pipe(gulp.dest(Config.APP_DEST));
 };
 

--- a/tools/tasks/seed/build.js.dev.ts
+++ b/tools/tasks/seed/build.js.dev.ts
@@ -3,6 +3,7 @@ import * as gulpLoadPlugins from 'gulp-load-plugins';
 import * as merge from 'merge-stream';
 import * as util from 'gulp-util';
 import { join/*, sep, relative*/ } from 'path';
+var newer = require('gulp-newer');
 
 import Config from '../../config';
 import { makeTsProject, templateLocals } from '../../utils';
@@ -29,7 +30,11 @@ export = () => {
     '!' + join(Config.APP_SRC, `**/${Config.BOOTSTRAP_FACTORY_PROD_MODULE}.ts`)
   ];
 
-  let projectFiles = gulp.src(src);
+  let projectFiles = gulp.src(src)
+       .pipe(newer({
+       dest: Config.APP_DEST, 
+       map: function(path: String) { return path.replace(".ts", ".js").replace(".sccs", ".css"); }
+     }));
   let result: any;
   let isFullCompile = true;
 


### PR DESCRIPTION
Please accept these [small] changes for speeding up compiles in dev.
Selective use of gulp-newer has been applied to avoid recompiling untouched files.
Additionally, one change to make `tsc --project tsconfig.json` succeed was added as well (this command helps speed some compiles on Windows machines).
