### PR TITLE
prod mode fix for analytics, and project override

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,4 +12,6 @@
     "nativescript/app/**/*.js": true,
     "ChromeDebugger-UserData/**/*": true
   }
+,
+"typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,4 @@
     "nativescript/app/**/*.js": true,
     "ChromeDebugger-UserData/**/*": true
   }
-,
-"typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/tools/config/project.config.ts
+++ b/tools/config/project.config.ts
@@ -12,7 +12,13 @@ export class ProjectConfig extends SeedAdvancedConfig {
   constructor() {
     super();
     // this.APP_TITLE = 'Put name of your app here';
-
+    
+    /**
+     * Default Analytics provider is Segment
+     * refer the to the integrations with: section in the readme for others. 
+     */
+    //this.APP_ANALYTICS = 'put the name of the analytics provider'
+    
     /* Enable typeless compiler runs (faster) between typed compiler runs. */
     // this.TYPED_COMPILE_INTERVAL = 5;
 

--- a/tools/config/seed-advanced.config.ts
+++ b/tools/config/seed-advanced.config.ts
@@ -72,7 +72,6 @@ export class SeedAdvancedConfig extends SeedConfig {
     this.SYSTEM_CONFIG.paths[this.BOOTSTRAP_MODULE] = `${this.APP_BASE}${this.BOOTSTRAP_MODULE}`;
     this.SYSTEM_CONFIG.paths['angulartics2'] = `${this.APP_BASE}node_modules/angulartics2/dist/index`;
     this.SYSTEM_CONFIG.paths['angulartics2/*'] = `${this.APP_BASE}node_modules/angulartics2/dist/*`;
-    //this.SYSTEM_CONFIG.paths['angulartics2/*'] = `${this.APP_BASE}node_modules/angulartics2/dist/*`;
     this.SYSTEM_CONFIG.paths['lodash'] = `${this.APP_BASE}node_modules/lodash/index`;
 
     // testing support for @ngrx/effects
@@ -97,7 +96,13 @@ export class SeedAdvancedConfig extends SeedConfig {
       main: 'bundles/index.js',
       defaultExtension: 'js'
     };
+    this.SYSTEM_CONFIG['packages']['angulartics2/providers'] = {
+      main: 'index.js',
+      defaultExtension: 'js'
+    };
+    
     this.SYSTEM_BUILDER_CONFIG.paths['angulartics2'] = `node_modules/angulartics2/dist/index.js`;
+    this.SYSTEM_BUILDER_CONFIG.paths['angulartics2/*'] = `node_modules/angulartics2/dist/providers/`+ this.APP_ANALYTICS + `/angulartics2-`+ this.APP_ANALYTICS + `.js`;
     this.SYSTEM_BUILDER_CONFIG.paths['lodash'] = `node_modules/lodash/index.js`;
     this.SYSTEM_BUILDER_CONFIG.paths['@ngrx/core'] = `node_modules/@ngrx/core/index.js`;
     this.SYSTEM_BUILDER_CONFIG.paths['@ngrx/store'] = `node_modules/@ngrx/store/index.js`;

--- a/tools/config/seed-advanced.config.ts
+++ b/tools/config/seed-advanced.config.ts
@@ -102,7 +102,7 @@ export class SeedAdvancedConfig extends SeedConfig {
     };
     
     this.SYSTEM_BUILDER_CONFIG.paths['angulartics2'] = `node_modules/angulartics2/dist/index.js`;
-    this.SYSTEM_BUILDER_CONFIG.paths['angulartics2/*'] = `node_modules/angulartics2/dist/providers/`+ this.APP_ANALYTICS + `/angulartics2-`+ this.APP_ANALYTICS + `.js`;
+    this.SYSTEM_BUILDER_CONFIG.paths['angulartics2/*'] = `node_modules/angulartics2/dist/providers/${this.APP_ANALYTICS}/angulartics2-${this.APP_ANALYTICS}.js`;
     this.SYSTEM_BUILDER_CONFIG.paths['lodash'] = `node_modules/lodash/index.js`;
     this.SYSTEM_BUILDER_CONFIG.paths['@ngrx/core'] = `node_modules/@ngrx/core/index.js`;
     this.SYSTEM_BUILDER_CONFIG.paths['@ngrx/store'] = `node_modules/@ngrx/store/index.js`;

--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -245,6 +245,11 @@ export class SeedConfig {
   TOOLS_DIR = 'tools';
 
   /**
+   * The Angulartics2 analytics provider.
+   */
+  APP_ANALYTICS = 'segment';
+
+  /**
    * The directory of the tasks provided by the seed.
    */
   SEED_TASKS_DIR = join(process.cwd(), this.TOOLS_DIR, 'tasks', 'seed');


### PR DESCRIPTION
Cleaned up commented line, added end of file line. Added simple project override for analytics provider based on provider names and structure of angulartics2 package. 

Fixed remaining production build issue with [#288](https://github.com/NathanWalker/angular-seed-advanced/issues/288)