### PR TITLE
#291 dotnetcore support feature

### DIFF
--- a/dotnetcore/_Layout.cshtml
+++ b/dotnetcore/_Layout.cshtml
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <base href="<%= APP_BASE %>">
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title><%= APP_TITLE %></title>
+  <meta name="description" content="">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <!-- inject:css -->
+  <!-- endinject -->
+
+  <% if (TARGET_DESKTOP) { %>
+  <!-- shims:js -->
+  <!-- endinject -->
+  <% } %>
+
+  <% if (BUILD_TYPE === 'prod') { %>
+  <!-- segment.io -->
+  <script type="text/javascript">
+  !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="3.1.0";
+
+  // REPLACE with your Segment.io write_key
+  analytics.load("XVDaTIQYy5g0akx5iTJmPozLKWFLkX6y");
+  analytics.page()
+  }}();
+  </script>
+  <% } %>
+
+</head>
+<body>
+	<div>
+		@RenderBody()
+	</div>
+
+  <script>
+  // Fixes undefined module function in SystemJS bundle
+  function module() {}
+  </script>
+
+  <% if (!TARGET_DESKTOP) { %>
+  <!-- shims:js -->
+  <!-- endinject -->
+  <% } %>
+
+  <% if (BUILD_TYPE === 'dev') { %>
+  <script src="<%= APP_BASE %>system-config.js"></script>
+  <% } %>
+
+  <!-- libs:js -->
+  <!-- endinject -->
+
+  <!-- inject:js -->
+  <!-- endinject -->
+
+  <% if (BUILD_TYPE === 'dev') { %>
+  <script>
+  System.import('<%= BOOTSTRAP_MODULE %>')
+    .catch(function (e) {
+      console.error(e,
+        'Report this error at https://github.com/NathanWalker/angular-seed-advanced/issues');
+    });
+  </script>
+  <% } %>
+
+  <% if (TARGET_DESKTOP && BUILD_TYPE !== 'prod') { %>
+  <script>require('electron-connect').client.create()</script>
+  <% } %>
+
+</body>
+</html>

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -29,6 +29,24 @@ gulp.task('build.dev.watch', (done: any) =>
               done));
 
 // --------------
+// Build mvc dev.
+gulp.task('build.mvc.dev', (done: any) => 
+  runSequence('clean.mvc',
+              'build.mvc.assets.dev',
+              'build.html_css',
+              'build.js.dev',
+              'build.mvc.layout.dev',
+              'copy.mvc.dev',
+              done));
+              
+// --------------
+// Build mvc dev watch.
+gulp.task('build.mvc.dev.watch', (done: any) =>
+  runSequence('build.mvc.dev',
+              'watch.mvc.dev',
+              done));
+
+// --------------
 // Build e2e.
 gulp.task('build.e2e', (done: any) =>
   runSequence('clean.dev',
@@ -69,6 +87,24 @@ gulp.task('build.prod.exp', (done: any) =>
               'build.bundles.app.exp',
               'minify.bundles',
               'build.index.prod',
+              done));
+
+// --------------
+// Build mvc prod.
+gulp.task('build.mvc.prod', (done: any) =>
+  runSequence('check.tools',
+              'clean.mvc',
+              'clean.prod',
+              'tslint',
+              'build.mvc.assets.prod',
+              'build.html_css',
+              'copy.prod',
+              'build.js.prod',
+              'build.bundles',
+              'build.bundles.app',
+              'minify.bundles',
+              'build.mvc.layout.prod',
+              'copy.mvc.prod',
               done));
 
 // --------------

--- a/tools/config/project.config.ts
+++ b/tools/config/project.config.ts
@@ -9,6 +9,9 @@ export class ProjectConfig extends SeedAdvancedConfig {
 
   PROJECT_TASKS_DIR = join(process.cwd(), this.TOOLS_DIR, 'tasks', 'project');
 
+  //The path to the root of your aspnet core MVC application.
+  APP_MVC_DEST : string = `../aspnetcore-angular-seed-advanced/`;
+
   constructor() {
     super();
     // this.APP_TITLE = 'Put name of your app here';

--- a/tools/tasks/project/build.mvc.assets.dev.ts
+++ b/tools/tasks/project/build.mvc.assets.dev.ts
@@ -1,0 +1,27 @@
+import * as gulp from 'gulp';
+import { join } from 'path';
+
+import { AssetsTask } from '../assets_task';
+import Config from '../../config';
+
+/**
+ * Executes the build process, copying the assets located in `src/client` over to the appropriate
+ * `dist/dev` directory.
+ */
+export =
+  class BuildAssetsTask extends AssetsTask {
+    run() {
+      let paths: string[] = [
+        join(Config.APP_SRC, '**'),
+        '!' + join(Config.APP_SRC, '**', '*.ts'),
+        '!' + join(Config.APP_SRC, '**', '*.scss'),
+        '!' + join(Config.APP_SRC, '**', '*.sass'),
+        '!' + join(Config.APP_SRC, '**', 'tsconfig.json'),
+        '!' + join(Config.APP_SRC, '**', 'index.html'),
+            ].concat(Config.TEMP_FILES.map((p) => { return '!' + p; }));
+
+      return gulp.src(paths)
+        .pipe(gulp.dest(Config.DEV_DEST));
+    }
+  };
+

--- a/tools/tasks/project/build.mvc.assets.prod.ts
+++ b/tools/tasks/project/build.mvc.assets.prod.ts
@@ -1,0 +1,36 @@
+import * as gulp from 'gulp';
+import { join } from 'path';
+
+import Config from '../../config';
+
+// TODO There should be more elegant to prevent empty directories from copying
+var onlyDirs = function (es: any) {
+  return es.map(function (file: any, cb: any) {
+    if (file.stat.isFile()) {
+      return cb(null, file);
+    } else {
+      return cb();
+    }
+  });
+};
+
+/**
+ * Executes the build process, copying the assets located in `src/client` over to the appropriate
+ * `dist/prod` directory.
+ */
+export = () => {
+  let es: any = require('event-stream');
+  return gulp.src([
+    join(Config.APP_SRC, '**'),
+    '!' + join(Config.APP_SRC, '**', '*.ts'),
+    '!' + join(Config.APP_SRC, '**', '*.css'),
+    '!' + join(Config.APP_SRC, '**', '*.html'),
+    '!' + join(Config.APP_SRC, '**', '*.scss'),
+    '!' + join(Config.APP_SRC, '**', '*.sass'),
+    '!' + join(Config.APP_SRC, '**', 'tsconfig.json'),
+    '!' + join(Config.APP_SRC, '**', 'index.html'),
+    '!' + join(Config.ASSETS_SRC, '**', '*.js')
+  ].concat(Config.TEMP_FILES.map((p) => { return '!' + p; })))
+    .pipe(onlyDirs(es))
+    .pipe(gulp.dest(Config.APP_DEST));
+};

--- a/tools/tasks/project/build.mvc.layout.dev.ts
+++ b/tools/tasks/project/build.mvc.layout.dev.ts
@@ -1,0 +1,79 @@
+import * as gulp from 'gulp';
+import * as gulpLoadPlugins from 'gulp-load-plugins';
+import { join } from 'path';
+import * as slash from 'slash';
+
+import Config from '../../config';
+import { templateLocals } from '../../utils';
+
+const plugins = <any>gulpLoadPlugins();
+
+
+/**
+ * Executes the build process, injecting the shims and libs into the `index.hml` for the development environment.
+ */
+export = () => {
+  return gulp.src(join(Config.APP_BASE, 'dotnetcore', '_Layout.cshtml'))
+    .pipe(inject('shims'))
+    .pipe(inject('libs'))
+    .pipe(inject())
+    .pipe(plugins.template(templateLocals()))
+    .pipe(gulp.dest(join(Config.APP_MVC_DEST, 'Views', 'Shared')));
+};
+
+/**
+ * Injects the file with the given name.
+ * @param {string} name - The file to be injected.
+ */
+function inject(name?: string) {
+  return plugins.inject(gulp.src(getInjectablesDependenciesRef(name), { read: false }), {
+    name,
+    transform: transformPath()
+  });
+}
+
+/**
+ * Returns the injectable dependency, mapping its filename to its path.
+ * @param {string} name - The dependency to be mapped.
+ */
+function getInjectablesDependenciesRef(name?: string) {
+  return Config.DEPENDENCIES
+    .filter(dep => dep['inject'] && dep['inject'] === (name || true))
+    .map(mapPath);
+}
+
+/**
+ * Maps the path of the given dependency to its path according to the applications environment.
+ * @param {any} dep - The dependency to be mapped.
+ */
+function mapPath(dep: any) {
+  let envPath = dep.src;
+  if (envPath.startsWith(Config.APP_SRC) && !envPath.endsWith('.scss')) {
+    envPath = join(Config.APP_DEST, envPath.replace(Config.APP_SRC, ''));
+  } else if (envPath.startsWith(Config.APP_SRC) && envPath.endsWith('.scss')) {
+    envPath = envPath.replace(Config.ASSETS_SRC, Config.CSS_DEST).replace('.scss', '.css');
+  }
+  return envPath;
+}
+
+/**
+ * Transform the path of a dependency to its location within the `dist` directory according to the applications
+ * environment.
+ */
+function transformPath() {
+  return function (filepath: string) {
+    if (filepath.startsWith(`/${Config.APP_DEST}`)) {
+      filepath = filepath.replace(`/${Config.APP_DEST}`, '');
+    }
+    if (Config.TARGET_DESKTOP) {
+      let path = join(Config.APP_BASE, filepath);
+      if (path.indexOf('dist/dev') > -1 || path.indexOf('dist\\dev') > -1) {
+        path = path.replace(/(dist\/dev\/)|(dist\\dev\\)/g, '');
+      }
+      arguments[0] = path.substring(1) + `?${Date.now()}`;
+    } else {
+      arguments[0] = join(Config.APP_BASE, filepath) + `?${Date.now()}`;
+    }
+    return slash(plugins.inject.transform.apply(plugins.inject.transform, arguments));
+  };
+}

--- a/tools/tasks/project/build.mvc.layout.prod.ts
+++ b/tools/tasks/project/build.mvc.layout.prod.ts
@@ -1,0 +1,64 @@
+import * as gulp from 'gulp';
+import * as gulpLoadPlugins from 'gulp-load-plugins';
+import { join, sep, normalize } from 'path';
+import * as slash from 'slash';
+
+import Config from '../../config';
+import { templateLocals } from '../../utils';
+
+const plugins = <any>gulpLoadPlugins();
+
+/**
+ * Executes the build process, injecting the JavaScript and CSS dependencies into the `index.html` for the production
+ * environment.
+ */
+export = () => {
+  return gulp.src(join(Config.APP_BASE, 'dotnetcore', '_Layout.cshtml'))
+    .pipe(injectJs())
+    .pipe(injectCss())
+    .pipe(plugins.template(templateLocals()))
+    .pipe(gulp.dest(join(Config.APP_MVC_DEST, 'Views', 'Shared')));
+};
+
+/**
+ * Injects the given file array and transforms the path of the files.
+ * @param {Array<string>} files - The files to be injected.
+ */
+function inject(...files: Array<string>) {
+    return plugins.inject(gulp.src(files, { read: false }), {
+        files,
+        transform: transformPath()
+    });
+}
+
+/**
+ * Injects the bundled JavaScript shims and application bundles for the production environment.
+ */
+function injectJs() {
+  return inject(join(Config.JS_DEST, Config.JS_PROD_SHIMS_BUNDLE), join(Config.JS_DEST, Config.JS_PROD_APP_BUNDLE));
+}
+
+/**
+ * Injects the bundled CSS files for the production environment.
+ */
+function injectCss() {
+  return inject(join(Config.CSS_DEST, Config.CSS_PROD_BUNDLE));
+}
+
+/**
+ * Transform the path of a dependency to its location within the `dist` directory according to the applications
+ * environment.
+ */
+function transformPath() {
+  return function(filepath: string) {
+    let path: Array<string> = normalize(filepath).split(sep);
+    let slice_after = path.indexOf(Config.APP_DEST);
+    if (slice_after>-1) {
+      slice_after++;
+    } else {
+      slice_after = 3;
+    }
+    arguments[0] = Config.APP_BASE + path.slice(slice_after, path.length).join(sep) + `?${Date.now()}`;
+    return slash(plugins.inject.transform.apply(plugins.inject.transform, arguments));
+  };
+}

--- a/tools/tasks/project/clean.mvc.ts
+++ b/tools/tasks/project/clean.mvc.ts
@@ -1,0 +1,11 @@
+import Config from '../../config';
+import { clean } from '../../utils';
+import { join } from 'path';
+
+/**
+ * Executes the build process, cleaning all files within the `/dist/dev` directory.
+ */
+export = clean([
+    join(Config.APP_MVC_DEST, 'Views/Shared/_Layout.cshtml'),
+    join(Config.APP_MVC_DEST, 'wwwroot')
+    ]);

--- a/tools/tasks/project/copy.mvc.dev.ts
+++ b/tools/tasks/project/copy.mvc.dev.ts
@@ -1,0 +1,26 @@
+import * as gulp from 'gulp';
+import { join } from 'path';
+
+import { AssetsTask } from '../assets_task';
+import Config from '../../config';
+
+/**
+ * Executes the build process, copying the assets located in `src/client` over to the appropriate
+ * `dist/dev` directory.
+ */
+export =
+  class BuildAssetsTask extends AssetsTask {
+    run() {
+      let paths: string[] = [
+        join(Config.DEV_DEST, '**'),
+        '!' + join(Config.APP_SRC, '**', 'tsconfig.json'),
+        '!' + join(Config.APP_SRC, '**', '*.ts'),
+        '!' + join(Config.APP_SRC, '**', '*.scss'),
+        '!' + join(Config.APP_SRC, '**', '*.sass')
+            ].concat(Config.TEMP_FILES.map((p) => { return '!' + p; }));
+
+      return gulp.src(paths)
+        .pipe(gulp.dest(join(Config.APP_MVC_DEST, 'wwwroot')));
+    }
+  };
+

--- a/tools/tasks/project/copy.mvc.prod.ts
+++ b/tools/tasks/project/copy.mvc.prod.ts
@@ -1,0 +1,26 @@
+import * as gulp from 'gulp';
+import { join } from 'path';
+
+import { AssetsTask } from '../assets_task';
+import Config from '../../config';
+
+/**
+ * Executes the build process, copying the assets located in `src/client` over to the appropriate
+ * `dist/dev` directory.
+ */
+export =
+  class BuildAssetsTask extends AssetsTask {
+    run() {
+      let paths: string[] = [
+        join(Config.PROD_DEST, '**'),
+        '!' + join(Config.APP_SRC, '**', 'tsconfig.json'),
+        '!' + join(Config.APP_SRC, '**', '*.ts'),
+        '!' + join(Config.APP_SRC, '**', '*.scss'),
+        '!' + join(Config.APP_SRC, '**', '*.sass')
+            ].concat(Config.TEMP_FILES.map((p) => { return '!' + p; }));
+
+      return gulp.src(paths)
+        .pipe(gulp.dest(join(Config.APP_MVC_DEST, 'wwwroot')));
+    }
+  };
+


### PR DESCRIPTION
Added directory for dotnet core output file [_Layout.cshtml](https://github.com/Kaffiend/angular-seed-advanced/blob/master/dotnetcore/_Layout.cshtml) to take it out of the root.

Created project build tasks for `build.mvc.dev` & `build.mvc.prod` to output the required files to the linking path set in [tools/config/project.config](https://github.com/Kaffiend/angular-seed-advanced/blob/master/tools/config/project.config.ts#L13) `APP_MVC_DEST` which are notated in the [/tools/tasks/project](https://github.com/Kaffiend/angular-seed-advanced/tree/master/tools/tasks/project) directory with a `.mvc.`

Consumer of the seed wishing to use dotnet core would simply setup the project as stated in the readme.md then set the path in the `project.config` to the root of their mvc application and the tasks will do the rest.

Since the production build of the seed includes the dependencies in the build process, a `build.mvc.dev`, other than the normal mvc angular 2 code, will require one addition to the `startup.cs` in the project and that is to map out the `node_modules` directory of the seed via a `PhysicalFileProvider` in the request pipeline, but this is only available with a "Development" environment variable. With a production build and environment variable the `node_modules` isnt supplied. 
Example:
```C#
app.UseStaticFiles();
            //prod build includes deps
            if (env.IsDevelopment()) 
            {
            app.UseStaticFiles(new StaticFileOptions
                {
                    FileProvider = new PhysicalFileProvider(Path.Combine(env.ContentRootPath, "../angular-seed-advanced/node_modules/" )),
                    RequestPath = "/node_modules"
                });
            }
```
