### PR TITLE
Integration with ng2-config

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -49,6 +49,7 @@ module.exports = function (config) {
 
       // Advanced seed
       { pattern: 'node_modules/lodash/**/*.js', included: false, watched: false },
+      { pattern: 'node_modules/ng2-config/**/*.js', included: false, watched: false },
       { pattern: 'node_modules/ng2-translate/**/*.js', included: false, watched: false },
       { pattern: 'node_modules/@ngrx/**/*.js', included: false, watched: false },
       { pattern: 'node_modules/angulartics2/**/*.js', included: false, watched: false },

--- a/nativescript/package.json
+++ b/nativescript/package.json
@@ -32,6 +32,7 @@
     "lodash": "^4.16.4",
     "nativescript-angular": "next",
     "nativescript-theme-core": "^1.0.2",
+    "ng2-config": "^1.1.1",
     "ng2-translate": "^4.2.0",
     "ngrx-store-freeze": "^0.1.0",
     "parse5": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -178,6 +178,7 @@
     "intl": "^1.2.5",
     "lodash": "^4.16.4",
     "minimatch": "^3.0.3",
+    "ng2-config": "^1.1.1",
     "ng2-translate": "^4.2.0",
     "reflect-metadata": "^0.1.8",
     "rxjs": "5.0.0-beta.12",

--- a/src/client/app.config.json
+++ b/src/client/app.config.json
@@ -1,0 +1,10 @@
+{
+  "logging": {
+    "DEBUG": {
+      "LEVEL_1": false,
+      "LEVEL_2": false,
+      "LEVEL_3": false,
+      "LEVEL_4": false
+    }
+  }
+}

--- a/src/client/app/frameworks/core/core.module.ts
+++ b/src/client/app/frameworks/core/core.module.ts
@@ -5,6 +5,9 @@ import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { HttpModule } from '@angular/http';
 
+// libs
+import { ConfigLoader, ConfigStaticLoader, ConfigModule, ConfigService } from 'ng2-config';
+
 // module
 import { CORE_DIRECTIVES } from './directives/index';
 import { CORE_PROVIDERS } from './services/index';
@@ -12,6 +15,11 @@ import { CORE_PROVIDERS } from './services/index';
 interface ICoreModuleOptions {
   window?: any;
   console?: any;
+}
+
+// for AoT compilation
+export function configFactory(): ConfigLoader {
+  return new ConfigStaticLoader('dist/dev/app.config.json');
 }
 
 /**
@@ -22,7 +30,8 @@ interface ICoreModuleOptions {
   imports: [
     CommonModule,
     RouterModule,
-    HttpModule
+    HttpModule,
+    ConfigModule.forRoot(),
   ],
   declarations: [
     CORE_DIRECTIVES

--- a/src/client/app/frameworks/core/services/log.service.spec.ts
+++ b/src/client/app/frameworks/core/services/log.service.spec.ts
@@ -1,36 +1,62 @@
 // angular
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
 import { TestBed } from '@angular/core/testing';
+import { BaseRequestOptions, Http, Response, ResponseOptions } from '@angular/http';
+import { MockBackend, MockConnection } from '@angular/http/testing';
+
+// libs
+import { ConfigModule, ConfigLoader, ConfigService } from 'ng2-config';
 
 // app
 import { t } from '../../test/index';
+import { configFactory } from '../../core/core.module';
 
 // module
-import { Config, ConsoleService, LogService } from '../index';
+import { ConsoleService, LogService } from '../index';
 
 const providers: Array<any> = [
   { provide: ConsoleService, useValue: console },
-  LogService
+  LogService,
+  {
+    provide: Http,
+    useFactory: (mockBackend: MockBackend, options: BaseRequestOptions) => {
+      return new Http(mockBackend, options);
+    },
+    deps: [MockBackend, BaseRequestOptions]
+  },
+  MockBackend,
+  BaseRequestOptions
 ];
+
+const mockBackendResponse = (connection: MockConnection, response: any) => {
+    connection.mockRespond(new Response(new ResponseOptions({ body: response })));
+};
 
 export function main() {
   t.describe('core: LogService', () => {
 
     t.be(() => {
       // ensure statics are in default state
-      Config.RESET();
+      //Config.RESET();
       // spy
       t.spyOn(console, 'log');
       t.spyOn(console, 'error');
       t.spyOn(console, 'warn');
       t.spyOn(console, 'info');
 
-      TestBed.configureTestingModule({
-        providers: providers
-      });
+      // reset the test environment before initializing it.
+      TestBed.resetTestEnvironment();
+
+      TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting())
+        .configureTestingModule({
+          imports: [
+            ConfigModule.forRoot({ provide: ConfigLoader, useFactory: (configFactory) })
+          ],
+          providers: providers
+        });
     });
 
     t.describe('api', () => {
-
       t.it('sanity', t.inject([LogService], (log: LogService) => {
         t.e(log.debug).toBeDefined();
         t.e(log.error).toBeDefined();
@@ -38,88 +64,172 @@ export function main() {
         t.e(log.info).toBeDefined();
       }));
 
-      t.it('should not log anything by default', t.inject([LogService], (log: LogService) => {
-        log.debug('debug');
-        t.e(console.log).not.toHaveBeenCalledWith('debug');
-        log.error('error');
-        t.e(console.error).not.toHaveBeenCalledWith('error');
-        log.warn('warn');
-        t.e(console.warn).not.toHaveBeenCalledWith('warn');
-        log.info('info');
-        t.e(console.info).not.toHaveBeenCalledWith('info');
-      }));
+      t.it('should not log anything by default',
+        t.async(t.inject([MockBackend, ConfigService, LogService],
+          (backend: MockBackend, config: ConfigService, log: LogService) => {
+            const mockSettings = {
+              logging: {
+                DEBUG: {
+                  LEVEL_1: false,
+                  LEVEL_2: false,
+                  LEVEL_3: false,
+                  LEVEL_4: false
+                }
+              }
+            };
+
+            // mock response
+            backend.connections.subscribe((c: MockConnection) => mockBackendResponse(c, mockSettings));
+
+            config.init()
+              .then(() => {
+                log.debug('debug');
+                t.e(console.log).not.toHaveBeenCalledWith('debug');
+                log.error('error');
+                t.e(console.error).not.toHaveBeenCalledWith('error');
+                log.warn('warn');
+                t.e(console.warn).not.toHaveBeenCalledWith('warn');
+                log.info('info');
+                t.e(console.info).not.toHaveBeenCalledWith('info');
+              });
+      })));
     });
 
     t.describe('debug levels', () => {
+      t.it('LEVEL_4: everything',
+        t.async(t.inject([MockBackend, ConfigService, LogService],
+          (backend: MockBackend, config: ConfigService, log: LogService) => {
+            const mockSettings = {
+              logging: {
+                DEBUG: {
+                  LEVEL_1: false,
+                  LEVEL_2: false,
+                  LEVEL_3: false,
+                  LEVEL_4: true
+                }
+              }
+            };
 
-      t.be(() => {
-        Config.RESET();
-      });
+            // mock response
+            backend.connections.subscribe((c: MockConnection) => mockBackendResponse(c, mockSettings));
 
-      t.it('LEVEL_4: everything', t.inject([LogService], (log: LogService) => {
-        Config.DEBUG.LEVEL_4 = true;
+            config.init()
+              .then(() => {
+                log.debug('debug');
+                t.e(console.log).toHaveBeenCalledWith('debug');
+                log.error('error');
+                t.e(console.error).toHaveBeenCalledWith('error');
+                log.warn('warn');
+                t.e(console.warn).toHaveBeenCalledWith('warn');
+                log.info('info');
+                t.e(console.info).toHaveBeenCalledWith('info');
+              });
+      })));
 
-        log.debug('debug');
-        t.e(console.log).toHaveBeenCalledWith('debug');
-        log.error('error');
-        t.e(console.error).toHaveBeenCalledWith('error');
-        log.warn('warn');
-        t.e(console.warn).toHaveBeenCalledWith('warn');
-        log.info('info');
-        t.e(console.info).toHaveBeenCalledWith('info');
-      }));
+      t.it('LEVEL_3: error only',
+        t.async(t.inject([MockBackend, ConfigService, LogService],
+          (backend: MockBackend, config: ConfigService, log: LogService) => {
+            const mockSettings = {
+              logging: {
+                DEBUG: {
+                  LEVEL_1: false,
+                  LEVEL_2: false,
+                  LEVEL_3: true,
+                  LEVEL_4: false
+                }
+              }
+            };
 
-      t.it('LEVEL_3: error only', t.inject([LogService], (log: LogService) => {
-        Config.DEBUG.LEVEL_3 = true;
+            // mock response
+            backend.connections.subscribe((c: MockConnection) => mockBackendResponse(c, mockSettings));
 
-        log.debug('debug');
-        t.e(console.log).not.toHaveBeenCalledWith('debug');
-        log.error('error');
-        t.e(console.error).toHaveBeenCalledWith('error');
-        log.warn('warn');
-        t.e(console.warn).not.toHaveBeenCalledWith('warn');
-        log.info('info');
-        t.e(console.info).not.toHaveBeenCalledWith('info');
+            config.init()
+              .then(() => {
+                log.debug('debug');
+                t.e(console.log).not.toHaveBeenCalledWith('debug');
+                log.error('error');
+                t.e(console.error).toHaveBeenCalledWith('error');
+                log.warn('warn');
+                t.e(console.warn).not.toHaveBeenCalledWith('warn');
+                log.info('info');
+                t.e(console.info).not.toHaveBeenCalledWith('info');
 
-        // always overrides lower levels and allows them to come through
-        Config.DEBUG.LEVEL_4 = true;
+                // always overrides lower levels and allows them to come through
+                mockSettings.logging.DEBUG.LEVEL_4 = true;
 
-        log.debug('debug w/level_4');
-        t.e(console.log).toHaveBeenCalledWith('debug w/level_4');
-        log.error('error w/level_4');
-        t.e(console.error).toHaveBeenCalledWith('error w/level_4');
-        log.warn('warn w/level_4');
-        t.e(console.warn).toHaveBeenCalledWith('warn w/level_4');
-        log.info('info w/level_4');
-        t.e(console.info).toHaveBeenCalledWith('info w/level_4');
-      }));
+                config.init()
+                  .then(() => {
+                    log.debug('debug w/level_4');
+                    t.e(console.log).toHaveBeenCalledWith('debug w/level_4');
+                    log.error('error w/level_4');
+                    t.e(console.error).toHaveBeenCalledWith('error w/level_4');
+                    log.warn('warn w/level_4');
+                    t.e(console.warn).toHaveBeenCalledWith('warn w/level_4');
+                    log.info('info w/level_4');
+                    t.e(console.info).toHaveBeenCalledWith('info w/level_4');
+                  });
+              });
+      })));
 
-      t.it('LEVEL_2: warn only', t.inject([LogService], (log: LogService) => {
-        Config.DEBUG.LEVEL_2 = true;
+      t.it('LEVEL_2: warn only',
+        t.async(t.inject([MockBackend, ConfigService, LogService],
+          (backend: MockBackend, config: ConfigService, log: LogService) => {
+            const mockSettings = {
+              logging: {
+                DEBUG: {
+                  LEVEL_1: false,
+                  LEVEL_2: true,
+                  LEVEL_3: false,
+                  LEVEL_4: false
+                }
+              }
+            };
 
-        log.debug('debug');
-        t.e(console.log).not.toHaveBeenCalledWith('debug');
-        log.error('error');
-        t.e(console.error).not.toHaveBeenCalledWith('error');
-        log.warn('warn');
-        t.e(console.warn).toHaveBeenCalledWith('warn');
-        log.info('info');
-        t.e(console.info).not.toHaveBeenCalledWith('info');
-      }));
+            // mock response
+            backend.connections.subscribe((c: MockConnection) => mockBackendResponse(c, mockSettings));
 
-      t.it('LEVEL_1: info only', t.inject([LogService], (log: LogService) => {
-        Config.DEBUG.LEVEL_1 = true;
+            config.init()
+              .then(() => {
+                log.debug('debug');
+                t.e(console.log).not.toHaveBeenCalledWith('debug');
+                log.error('error');
+                t.e(console.error).not.toHaveBeenCalledWith('error');
+                log.warn('warn');
+                t.e(console.warn).toHaveBeenCalledWith('warn');
+                log.info('info');
+                t.e(console.info).not.toHaveBeenCalledWith('info');
+              });
+      })));
 
-        log.debug('debug');
-        t.e(console.log).not.toHaveBeenCalledWith('debug');
-        log.error('error');
-        t.e(console.error).not.toHaveBeenCalledWith('error');
-        log.warn('warn');
-        t.e(console.warn).not.toHaveBeenCalledWith('warn');
-        log.info('info');
-        t.e(console.info).toHaveBeenCalledWith('info');
-      }));
+      t.it('LEVEL_1: info only',
+        t.async(t.inject([MockBackend, ConfigService, LogService],
+          (backend: MockBackend, config: ConfigService, log: LogService) => {
+            const mockSettings = {
+              logging: {
+                DEBUG: {
+                  LEVEL_1: true,
+                  LEVEL_2: false,
+                  LEVEL_3: false,
+                  LEVEL_4: false
+                }
+              }
+            };
+
+            // mock response
+            backend.connections.subscribe((c: MockConnection) => mockBackendResponse(c, mockSettings));
+
+            config.init()
+              .then(() => {
+                log.debug('debug');
+                t.e(console.log).not.toHaveBeenCalledWith('debug');
+                log.error('error');
+                t.e(console.error).not.toHaveBeenCalledWith('error');
+                log.warn('warn');
+                t.e(console.warn).not.toHaveBeenCalledWith('warn');
+                log.info('info');
+                t.e(console.info).toHaveBeenCalledWith('info');
+              });
+      })));
     });
   });
-
 }

--- a/src/client/app/frameworks/core/services/log.service.ts
+++ b/src/client/app/frameworks/core/services/log.service.ts
@@ -1,18 +1,23 @@
 // angular
 import { Injectable, Inject, forwardRef } from '@angular/core';
 
+// lib
+import { ConfigService } from 'ng2-config';
+
 // module
-import { Config } from '../utils/config';
+//import { Config } from '../utils/config';
 import { ConsoleService } from './console.service';
 
 @Injectable()
 export class LogService {
 
-  constructor(@Inject(forwardRef(() => ConsoleService)) public logger: ConsoleService) {}
+  constructor(private config: ConfigService,
+              @Inject(forwardRef(() => ConsoleService)) public logger: ConsoleService) {}
 
   // debug (standard output)
   public debug(msg: any) {
-    if (Config.DEBUG.LEVEL_4) {
+    //if (Config.DEBUG.LEVEL_4) {
+    if (this.config.getSettings().logging.DEBUG.LEVEL_4) {
       // console.debug does not work on {N} apps... use `log`
       this.logger.log(msg);
     }
@@ -20,21 +25,24 @@ export class LogService {
 
   // error
   public error(err: any) {
-    if (Config.DEBUG.LEVEL_4 || Config.DEBUG.LEVEL_3) {
+    //if (Config.DEBUG.LEVEL_4 || Config.DEBUG.LEVEL_3) {
+    if (this.config.getSettings().logging.DEBUG.LEVEL_4 || this.config.getSettings().logging.DEBUG.LEVEL_3) {
       this.logger.error(err);
     }
   }
 
   // warn
   public warn(err: any) {
-    if (Config.DEBUG.LEVEL_4 || Config.DEBUG.LEVEL_2) {
+    //if (Config.DEBUG.LEVEL_4 || Config.DEBUG.LEVEL_2) {
+    if (this.config.getSettings().logging.DEBUG.LEVEL_4 || this.config.getSettings().logging.DEBUG.LEVEL_2) {
       this.logger.warn(err);
     }
   }
 
   // info
   public info(err: any) {
-    if (Config.DEBUG.LEVEL_4 || Config.DEBUG.LEVEL_1) {
+    //if (Config.DEBUG.LEVEL_4 || Config.DEBUG.LEVEL_1) {
+    if (this.config.getSettings().logging.DEBUG.LEVEL_4 || this.config.getSettings().logging.DEBUG.LEVEL_1) {
       this.logger.info(err);
     }
   }

--- a/src/client/app/frameworks/core/testing/mocks/ng2-config.mock.ts
+++ b/src/client/app/frameworks/core/testing/mocks/ng2-config.mock.ts
@@ -1,0 +1,18 @@
+export class ConfigMock {
+  init(): any {
+    return null;
+  }
+
+  getSettings(group?: string, key?: string): any {
+    return {
+      logging: {
+        DEBUG: {
+          LEVEL_1: false,
+          LEVEL_2: false,
+          LEVEL_3: false,
+          LEVEL_4: false
+        }
+      }
+    };
+  }
+}

--- a/src/client/app/frameworks/core/testing/providers/core.ts
+++ b/src/client/app/frameworks/core/testing/providers/core.ts
@@ -1,3 +1,6 @@
+// libs
+import { ConfigService } from 'ng2-config';
+
 // app
 import { ANALYTICS_PROVIDERS } from '../../../analytics/index';
 
@@ -7,6 +10,7 @@ import { WindowService, ConsoleService, LogService, RouterExtensions } from '../
 // mocks
 import { WindowMock } from '../mocks/window.mock';
 import { RouterExtensionsMock } from '../mocks/router-extensions.mock';
+import { ConfigMock } from '../mocks/ng2-config.mock';
 
 export function TEST_CORE_PROVIDERS(options?: any): Array<any> {
   // options:
@@ -16,6 +20,7 @@ export function TEST_CORE_PROVIDERS(options?: any): Array<any> {
     { provide: ConsoleService, useValue: console },
     { provide: WindowService, useClass: (options && options.window) || WindowMock },
     LogService,
+    { provide: ConfigService, useClass: (options && options.config) || ConfigMock },
     ANALYTICS_PROVIDERS,
     { provide: RouterExtensions, useClass: RouterExtensionsMock },
   ];

--- a/src/client/app/frameworks/i18n/components/lang-switcher.component.spec.ts
+++ b/src/client/app/frameworks/i18n/components/lang-switcher.component.spec.ts
@@ -1,17 +1,25 @@
+// angular
 import { TestBed } from '@angular/core/testing';
 import { Component } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
 
 // libs
 import { StoreModule } from '@ngrx/store';
+import { ConfigService } from 'ng2-config';
 
+// app
 import { t } from '../../test/index';
 import { ILang, WindowService, ConsoleService } from '../../core/index';
 import { CoreModule } from '../../core/core.module';
 import { AnalyticsModule } from '../../analytics/analytics.module';
+
+// module
 import { MultilingualModule } from '../multilingual.module';
 import { MultilingualService, reducer } from '../index';
 import { TEST_MULTILINGUAL_RESET } from '../testing/index';
+
+// mocks
+import { ConfigMock } from '../../core/testing/mocks/ng2-config.mock';
 
 const SUPPORTED_LANGUAGES: Array<ILang> = [
   { code: 'en', title: 'English' },
@@ -27,7 +35,8 @@ const testModuleConfig = () => {
     imports: [
       CoreModule.forRoot([
         { provide: WindowService, useValue: window },
-        { provide: ConsoleService, useValue: console }
+        { provide: ConsoleService, useValue: console },
+        { provide: ConfigService, useClass: ConfigMock },
       ]),
       RouterTestingModule,
       AnalyticsModule,

--- a/src/client/web.module.ts
+++ b/src/client/web.module.ts
@@ -9,6 +9,7 @@ import { Http } from '@angular/http';
 import { StoreModule } from '@ngrx/store';
 import { EffectsModule } from '@ngrx/effects';
 import { StoreDevtoolsModule } from '@ngrx/store-devtools';
+import { ConfigLoader, ConfigService } from 'ng2-config';
 import { TranslateLoader } from 'ng2-translate';
 
 // app
@@ -16,7 +17,7 @@ import { APP_COMPONENTS, AppComponent } from './app/components/index';
 import { routes } from './app/components/app.routes';
 
 // feature modules
-import { CoreModule } from './app/frameworks/core/core.module';
+import { CoreModule, configFactory } from './app/frameworks/core/core.module';
 import { AppReducer } from './app/frameworks/ngrx/index';
 import { AnalyticsModule } from './app/frameworks/analytics/analytics.module';
 import { MultilingualModule, translateFactory } from './app/frameworks/i18n/multilingual.module';
@@ -61,7 +62,8 @@ export function cons() {
     BrowserModule,
     CoreModule.forRoot([
       { provide: WindowService, useFactory: (win) },
-      { provide: ConsoleService, useFactory: (cons) }
+      { provide: ConsoleService, useFactory: (cons) },
+      { provide: ConfigLoader, useFactory: (configFactory) }
     ]),
     routerModule,
     AnalyticsModule,

--- a/tools/config/seed-advanced.config.ts
+++ b/tools/config/seed-advanced.config.ts
@@ -78,6 +78,13 @@ export class SeedAdvancedConfig extends SeedConfig {
         }
       },
       {
+        name: 'ng2-config',
+        packageMeta: {
+          main: 'bundles/ng2-config.umd.min.js',
+          defaultExtension: 'js'
+        }
+      },
+      {
         name: 'ng2-translate',
         packageMeta: {
           main: 'bundles/index.js',

--- a/tools/tasks/project/desktop.libs.ts
+++ b/tools/tasks/project/desktop.libs.ts
@@ -9,6 +9,7 @@ export = () => {
     'node_modules/rxjs/**/*',
     'node_modules/angulartics2/**/*',
     'node_modules/lodash/**/*',
+    'node_modules/ng2-config/**/*',
     'node_modules/ng2-translate/**/*',
     'node_modules/@ngrx/**/*',
     'node_modules/ngrx-store-freeze/**/*',


### PR DESCRIPTION
This pull request contains integration with `ng2-config`, a configuration utlilty for Angular2, which fetches and loads the configuration settings from a **JSON file** (or **API**) during application initialization (uses __APP_INITIALIZER__). I believe it can contribute to make the source code cleaner by moving application configuration towards **API services/JSON files**.

I have been established the `ng2-config` integration further with **i18n** and other components of the seed project - on my current projects. However, with this pull request I kept the scope so narrow: only **log-service** has been integrated with `ng2-config`. According to the mergeability and community feedback I'll sync the `ng2-config` integration with further services and components.

Furthermore, I have successfully integrated the seed project with `ng2-metadata` - another utility for Angular2 which dynamically generates page title and meta tags. I'd be happy to contribute to the project integrating `ng2-metadata` in a structured way.