### PR TITLE
Integrate ng2-config with i18n

### DIFF
--- a/src/client/app.config.json
+++ b/src/client/app.config.json
@@ -1,4 +1,16 @@
 {
+  "i18n": {
+    "defaultLanguage": {
+      "code": "en",
+      "title": "English"
+    },
+    "availableLanguages": [
+      {
+        "code": "en",
+        "title": "English"
+      }
+    ]
+  },
   "logging": {
     "DEBUG": {
       "LEVEL_1": false,

--- a/src/client/app/components/app.component.spec.ts
+++ b/src/client/app/components/app.component.spec.ts
@@ -1,14 +1,21 @@
+// angular
 import { TestBed } from '@angular/core/testing';
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { Route } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+
+// libs
 import { StoreModule } from '@ngrx/store';
 
+// app
 import { t } from '../frameworks/test/index';
 import { TEST_CORE_PROVIDERS, TEST_HTTP_PROVIDERS } from '../frameworks/core/testing/index';
 import { NameListService, NavbarComponent, ToolbarComponent } from '../frameworks/sample/index';
 import { MultilingualModule } from '../frameworks/i18n/multilingual.module';
+import { reducer } from '../frameworks/i18n/index';
+
+// module
 import { AppComponent } from './app.component';
 import { HomeComponent } from './home/home.component';
 import { AboutComponent } from './about/about.component';
@@ -24,7 +31,7 @@ const testModuleConfig = () => {
     imports: [
       FormsModule,
       MultilingualModule,
-      StoreModule.provideStore({}),
+      StoreModule.provideStore({ i18n: reducer }),
       RouterTestingModule.withRoutes(config)
     ],
     declarations: [

--- a/src/client/app/components/app.component.ts
+++ b/src/client/app/components/app.component.ts
@@ -1,10 +1,14 @@
 // angular
-import { ChangeDetectionStrategy } from '@angular/core';
+import { ChangeDetectionStrategy, OnInit } from '@angular/core';
 // any operators needed throughout your application
 import './operators';
 
+// libs
+import { ConfigService } from 'ng2-config';
+
 // app
 import { AnalyticsService } from '../frameworks/analytics/index';
+import { MultilingualService } from '../frameworks/i18n/index';
 import { BaseComponent, Config, LogService } from '../frameworks/core/index';
 
 /**
@@ -16,8 +20,15 @@ import { BaseComponent, Config, LogService } from '../frameworks/core/index';
   templateUrl: 'app.component.html',
   changeDetection: ChangeDetectionStrategy.Default // Everything else uses OnPush
 })
-export class AppComponent {
-  constructor(public analytics: AnalyticsService, public logger: LogService) {
+export class AppComponent implements OnInit {
+  constructor(public analytics: AnalyticsService,
+              public multilang: MultilingualService,
+              public logger: LogService,
+              private config: ConfigService) {
     logger.debug(`Config env: ${Config.ENVIRONMENT().ENV}`);
+  }
+
+  ngOnInit(): void {
+    this.multilang.init(this.config.getSettings().i18n);
   }
 }

--- a/src/client/app/frameworks/core/testing/mocks/ng2-config.mock.ts
+++ b/src/client/app/frameworks/core/testing/mocks/ng2-config.mock.ts
@@ -5,6 +5,50 @@ export class ConfigMock {
 
   getSettings(group?: string, key?: string): any {
     return {
+      i18n: {
+        defaultLanguage: {
+          code: 'en',
+          title: 'English'
+        },
+        availableLanguages: [
+          {
+            code: 'en',
+            title: 'English'
+          }
+        ]
+      },
+      logging: {
+        DEBUG: {
+          LEVEL_1: false,
+          LEVEL_2: false,
+          LEVEL_3: false,
+          LEVEL_4: false
+        }
+      }
+    };
+  }
+}
+
+export class ConfigMockMultilang {
+  init(): any {
+    return null;
+  }
+
+  getSettings(group?: string, key?: string): any {
+    return {
+      i18n: {
+        defaultLanguage: {
+          code: 'en',
+          title: 'English'
+        },
+        availableLanguages: [
+          { code: 'en', title: 'English' },
+          { code: 'es', title: 'Spanish' },
+          { code: 'fr', title: 'French' },
+          { code: 'ru', title: 'Russian' },
+          { code: 'bg', title: 'Bulgarian' }
+        ]
+      },
       logging: {
         DEBUG: {
           LEVEL_1: false,

--- a/src/client/app/frameworks/core/testing/mocks/window.mock.ts
+++ b/src/client/app/frameworks/core/testing/mocks/window.mock.ts
@@ -18,3 +18,10 @@ export class WindowMockFrench extends WindowMock {
     this.navigator.language = 'fr-US';
   }
 }
+
+export class WindowMockNoLanguage extends WindowMock {
+  constructor() {
+    super();
+    this.navigator.language = undefined;
+  }
+}

--- a/src/client/app/frameworks/i18n/components/lang-switcher.component.spec.ts
+++ b/src/client/app/frameworks/i18n/components/lang-switcher.component.spec.ts
@@ -1,6 +1,6 @@
 // angular
 import { TestBed } from '@angular/core/testing';
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
 
 // libs
@@ -16,10 +16,9 @@ import { AnalyticsModule } from '../../analytics/analytics.module';
 // module
 import { MultilingualModule } from '../multilingual.module';
 import { MultilingualService, reducer } from '../index';
-import { TEST_MULTILINGUAL_RESET } from '../testing/index';
 
 // mocks
-import { ConfigMock } from '../../core/testing/mocks/ng2-config.mock';
+import { ConfigMock, ConfigMockMultilang } from '../../core/testing/mocks/ng2-config.mock';
 
 const SUPPORTED_LANGUAGES: Array<ILang> = [
   { code: 'en', title: 'English' },
@@ -30,13 +29,13 @@ const SUPPORTED_LANGUAGES: Array<ILang> = [
 ];
 
 // test module configuration for each test
-const testModuleConfig = () => {
+const testModuleConfig = (multilang: boolean = false) => {
   TestBed.configureTestingModule({
     imports: [
       CoreModule.forRoot([
         { provide: WindowService, useValue: window },
         { provide: ConsoleService, useValue: console },
-        { provide: ConfigService, useClass: ConfigMock },
+        { provide: ConfigService, useClass: multilang ? ConfigMockMultilang : ConfigMock },
       ]),
       RouterTestingModule,
       AnalyticsModule,
@@ -50,7 +49,9 @@ const testModuleConfig = () => {
 export function main() {
   t.describe('i18n:', () => {
     t.describe('@Component: LangSwitcherComponent', () => {
-      t.be(testModuleConfig);
+      t.be(() => {
+        testModuleConfig();
+      });
 
       t.it('should work',
         t.async(() => {
@@ -67,12 +68,8 @@ export function main() {
 
     t.describe('@Component: LangSwitcherComponent with multiple languages', () => {
       t.be(() => {
-        MultilingualService.SUPPORTED_LANGUAGES = SUPPORTED_LANGUAGES;
-        testModuleConfig();
+        testModuleConfig(true);
       });
-
-      // ensure statics are reset when the test had modified statics in a beforeEach (be) or beforeEachProvider (bep)
-      t.ae(() => TEST_MULTILINGUAL_RESET());
 
       t.it('should work',
         t.async(() => {
@@ -97,4 +94,9 @@ export function main() {
   selector: 'test-cmp',
   template: '<lang-switcher></lang-switcher>'
 })
-class TestComponent {}
+class TestComponent  {
+  constructor(private multilang: MultilingualService,
+              private config: ConfigService) {
+    this.multilang.init(this.config.getSettings().i18n);
+  }
+}

--- a/src/client/app/frameworks/i18n/components/lang-switcher.component.spec.ts
+++ b/src/client/app/frameworks/i18n/components/lang-switcher.component.spec.ts
@@ -1,6 +1,6 @@
 // angular
 import { TestBed } from '@angular/core/testing';
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
 
 // libs

--- a/src/client/app/frameworks/i18n/components/lang-switcher.component.ts
+++ b/src/client/app/frameworks/i18n/components/lang-switcher.component.ts
@@ -14,14 +14,16 @@ import * as multilingual from '../index';
   styleUrls: ['lang-switcher.component.css']
 })
 export class LangSwitcherComponent {
-
   public lang: string;
-  public supportedLanguages: Array<ILang> = multilingual.MultilingualService.SUPPORTED_LANGUAGES;
+  public supportedLanguages: Array<ILang>;
 
-  constructor(private log: LogService, private store: Store<IAppState>) {
+  constructor(public multilang: multilingual.MultilingualService,
+              private log: LogService,
+              private store: Store<IAppState>) {
     store.take(1).subscribe((s: any) => {
       // s && s.18n - ensures testing works in all cases (since some tests dont use i18n state)
-      this.lang = s && s.i18n ? s.i18n.lang : '';
+      this.lang = s && s.i18n ? s.i18n.lang : this.multilang.defaultLanguage.code;
+      this.supportedLanguages = this.multilang.availableLanguages;
     });
 
     if (Config.IS_DESKTOP()) {
@@ -33,16 +35,17 @@ export class LangSwitcherComponent {
   }
   
   changeLang(e: any) {
-    let lang = this.supportedLanguages[0].code; // fallback to default 'en'
+    let lang = this.multilang.defaultLanguage.code; // fallback to default
 
     if (Config.IS_MOBILE_NATIVE()) {
       if (e) {
-        lang = this.supportedLanguages[e.newIndex].code;
+        lang = this.multilang.availableLanguages[e.newIndex].code;
       }
     } else if (e && e.target) {
       lang = e.target.value;
     }
+
     this.log.debug(`Language change: ${lang}`);
-    this.store.dispatch(new multilingual.ChangeAction(lang));
+    this.multilang.changeLang(lang);
   }
 }

--- a/src/client/app/frameworks/i18n/effects/multilingual.effect.ts
+++ b/src/client/app/frameworks/i18n/effects/multilingual.effect.ts
@@ -19,7 +19,7 @@ export class MultilingualEffects {
     .ofType(multilingual.ActionTypes.CHANGE)
     .map(action => {
       let lang = action.payload;
-      if (includes(map(MultilingualService.SUPPORTED_LANGUAGES, 'code'), lang)) {
+      if (includes(map(this.multilangService.availableLanguages, 'code'), lang)) {
         let langChangedAction = new multilingual.LangChangedAction(lang); 
         // track analytics
         this.multilangService.track(langChangedAction.type, { label: langChangedAction.payload });

--- a/src/client/app/frameworks/i18n/reducers/multilingual.reducer.ts
+++ b/src/client/app/frameworks/i18n/reducers/multilingual.reducer.ts
@@ -8,10 +8,12 @@ export function reducer(
 ): IMultilingualState {
   switch (action.type) {
     case ActionTypes.LANG_CHANGED:
-      return (<any>Object).assign({}, state, {
-        lang: action.payload
-      });
+      if (state.lang !== action.payload)
+        return Object.assign({}, state, {
+            lang: action.payload
+          });
 
+      return state;
     default:
       return state;
   }

--- a/src/client/app/frameworks/i18n/services/multilingual.service.spec.ts
+++ b/src/client/app/frameworks/i18n/services/multilingual.service.spec.ts
@@ -1,86 +1,162 @@
 // angular
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
 import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import { BaseRequestOptions, Http, Response, ResponseOptions } from '@angular/http';
+import { MockBackend, MockConnection } from '@angular/http/testing';
 
 // libs
 import { Store, StoreModule } from '@ngrx/store';
 import { EffectsModule } from '@ngrx/effects';
+import { ConfigLoader, ConfigService } from 'ng2-config';
 
 // app
 import { t } from '../../test/index';
-import { CoreModule } from '../../core/core.module';
+import { CoreModule, configFactory } from '../../core/core.module';
 import { ILang, WindowService, ConsoleService } from '../../core/index';
-import { TEST_CORE_PROVIDERS, WindowMockFrench } from '../../core/testing/index';
+import { TEST_CORE_PROVIDERS, WindowMockFrench, WindowMockNoLanguage  } from '../../core/testing/index';
 
 // module
-import { TEST_MULTILINGUAL_PROVIDERS, TEST_MULTILINGUAL_RESET } from '../testing/index';
+import { TEST_MULTILINGUAL_PROVIDERS } from '../testing/index';
 import { IMultilingualState, MultilingualService, MultilingualEffects, reducer, ChangeAction } from '../index';
+
+const mockSettings = {
+  i18n: {
+    defaultLanguage: {
+      code: 'fr',
+      title: 'Français'
+    },
+    availableLanguages: [
+      {
+        code: 'en',
+        title: 'English'
+      },
+      {
+        code: 'fr',
+        title: 'Français'
+      }
+    ]
+  }
+};
+
+const mockBackendResponse = (connection: MockConnection, response: any) => {
+    connection.mockRespond(new Response(new ResponseOptions({ body: response })));
+};
 
 // test module configuration for each test
 const testModuleConfig = (options?: any) => {
-  TestBed.configureTestingModule({
-    imports: [
-      CoreModule.forRoot([
-        { provide: WindowService, useValue: window },
-        { provide: ConsoleService, useValue: console }
-      ]),
-      StoreModule.provideStore({ i18n: reducer }),
-      EffectsModule.run(MultilingualEffects),
-      RouterTestingModule
-    ],
-    providers: [
-      TEST_CORE_PROVIDERS(options),
-      TEST_MULTILINGUAL_PROVIDERS()
-    ]
-  });
+  // reset the test environment before initializing it.
+  TestBed.resetTestEnvironment();
+
+  TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting())
+    .configureTestingModule({
+      imports: [
+        CoreModule.forRoot([
+          { provide: WindowService, useValue: window },
+          { provide: ConsoleService, useValue: console },
+          { provide: ConfigLoader, useFactory: (configFactory) }
+        ]),
+        StoreModule.provideStore({ i18n: reducer }),
+        EffectsModule.run(MultilingualEffects),
+        RouterTestingModule
+      ],
+      providers: [
+        TEST_CORE_PROVIDERS(options),
+        TEST_MULTILINGUAL_PROVIDERS(),
+        {
+          provide: Http,
+          useFactory: (mockBackend: MockBackend, options: BaseRequestOptions) => {
+            return new Http(mockBackend, options);
+          },
+          deps: [MockBackend, BaseRequestOptions]
+        },
+        MockBackend,
+        BaseRequestOptions
+      ]
+    });
 };
 
 export function main() {
   t.describe('i18n:', () => {
     t.describe('MultilingualService', () => {
-
       t.be(() => {
         testModuleConfig();
       });
 
-      t.it('should at a minimum support english', () => {
-        t.e(MultilingualService.SUPPORTED_LANGUAGES.length).toBe(1);
-        t.e(MultilingualService.SUPPORTED_LANGUAGES[0].code).toBe('en');
-      });
+      t.it('should at a minimum support english',
+        t.inject([ConfigService, MultilingualService],
+          (config: ConfigService, multilang: MultilingualService) => {
+            multilang.init(config.getSettings().i18n);
 
-      t.it('changeLang - should not switch unless supported', t.inject([MultilingualService, Store], (multilang: MultilingualService, store: Store<any>) => {
-        store.dispatch(new ChangeAction('fr'));
-        // only 'en' supported by default so changing to 'fr' should not change state
-        store.select('i18n').subscribe((i18n: IMultilingualState) => {
-          t.e(i18n.lang).toBe('en');
-        });
-      }));
+            t.e(multilang.availableLanguages.length).toBe(1);
+            t.e(multilang.availableLanguages[0].code).toBe('en');
+          }));
 
+      t.it('changeLang - should not switch unless supported',
+        t.inject([ConfigService, MultilingualService, Store],
+          (config: ConfigService, multilang: MultilingualService, store: Store<any>) => {
+            multilang.init(config.getSettings().i18n);
+            multilang.changeLang('fr');
+
+            // only 'en' supported by default so changing to 'fr' should not change state
+            store.select('i18n')
+              .subscribe((i18n: IMultilingualState) => {
+                t.e(i18n.lang).toBe('en');
+              });
+          }));
     });
 
     t.describe('MultilingualService for French browser/platform', () => {
-      const SUPPORTED_LANGUAGES: Array<ILang> = [
-        { code: 'en', title: 'English' },
-        { code: 'fr', title: 'French' }
-      ];
-
       t.be(() => {
-        MultilingualService.SUPPORTED_LANGUAGES = SUPPORTED_LANGUAGES;
-        testModuleConfig({ window: WindowMockFrench });
+        testModuleConfig({
+          window: WindowMockFrench,
+          config: ConfigService
+        });
       });
 
-      // ensure statics are reset when the test had modified statics in a beforeEach (be) or beforeEachProvider (bep)
-      t.ae(() => TEST_MULTILINGUAL_RESET());
+      t.it('should now support french by default',
+        t.async(t.inject([MockBackend, ConfigService, MultilingualService, Store, WindowService],
+          (backend: MockBackend, config: ConfigService, multilang: MultilingualService, store: Store<any>, win: WindowService) => {
+            // mock response
+            backend.connections.subscribe((c: MockConnection) => mockBackendResponse(c, mockSettings));
 
-      t.it('should now support french by default', t.inject([MultilingualService, Store, WindowService], (multilang: MultilingualService, store: Store<any>, win: WindowService) => {
-        t.e(MultilingualService.SUPPORTED_LANGUAGES.length).toBe(2);
-        t.e(MultilingualService.SUPPORTED_LANGUAGES[0].code).toBe('en');
-        t.e(MultilingualService.SUPPORTED_LANGUAGES[1].code).toBe('fr');
-        t.e(win.navigator.language).toBe('fr-US');
+            config.init()
+              .then(() => {
+                multilang.init(config.getSettings().i18n);
 
-        store.select('i18n').subscribe((i18n: IMultilingualState) => {
-          t.e(i18n.lang).toBe('fr');
+                t.e(multilang.availableLanguages.length).toBe(2);
+                t.e(multilang.availableLanguages[0].code).toBe('en');
+                t.e(multilang.availableLanguages[1].code).toBe('fr');
+                t.e(win.navigator.language).toBe('fr-US');
+
+                store.select('i18n')
+                  .subscribe((i18n: IMultilingualState) => {
+                    t.e(i18n.lang).toBe('fr');
+                  });
+                });
+      })));
+    });
+
+    t.describe('MultilingualService for languageless browser/platform', () => {
+      t.be(() => {
+        testModuleConfig({
+          window: WindowMockNoLanguage
         });
+      });
+
+      t.it('should now support english by default',
+        t.inject([ConfigService, MultilingualService, Store, WindowService],
+          (config: ConfigService, multilang: MultilingualService, store: Store<any>, win: WindowService) => {
+            multilang.init(config.getSettings().i18n);
+
+            t.e(multilang.availableLanguages.length).toBe(1);
+            t.e(multilang.availableLanguages[0].code).toBe('en');
+            t.e(win.navigator.language).toBeUndefined();
+
+            store.select('i18n')
+              .subscribe((i18n: IMultilingualState) => {
+                t.e(i18n.lang).toBe('en');
+              });
       }));
     });
   });

--- a/src/client/app/frameworks/i18n/services/multilingual.service.ts
+++ b/src/client/app/frameworks/i18n/services/multilingual.service.ts
@@ -20,9 +20,13 @@ export class MultilingualService extends Analytics {
 
   // default supported languages
   // see web.module.ts for example of how to provide different value
-  public static SUPPORTED_LANGUAGES: Array<ILang> = [
-    { code: 'en', title: 'English' }
-  ];
+  // public static SUPPORTED_LANGUAGES: Array<ILang> = [
+  //   { code: 'en', title: 'English' }
+  // ];
+
+  // default & available languages at instance level
+  defaultLanguage: ILang;
+  availableLanguages: Array<ILang>;
 
   constructor(
     public analytics: AnalyticsService,
@@ -33,19 +37,31 @@ export class MultilingualService extends Analytics {
     super(analytics);
     this.category = CATEGORY;
 
-    // this language will be used as a fallback when a translation isn't found in the current language
-    translate.setDefaultLang('en');
-
-    // use browser/platform lang if available
-    let userLang = win.navigator.language.split('-')[0];
-
     // subscribe to changes
-    store.select('i18n').subscribe((state: IMultilingualState) => {
-      // update ng2-translate which will cause translations to occur wherever the TranslatePipe is used in the view
-      this.translate.use(state.lang);
+    store.select('i18n')
+      .subscribe((state: IMultilingualState) => {
+        if (!!state && !!state.lang)
+          // update ng2-translate which will cause translations to occur wherever the TranslatePipe is used in the view
+          this.translate.use(state.lang);
     });
+  }
+
+  init(settings: any): void {
+    this.defaultLanguage = settings.defaultLanguage;
+    this.availableLanguages = settings.availableLanguages;
+
+    // this language will be used as a fallback when a translation isn't found in the current language
+    this.translate.setDefaultLang(this.defaultLanguage.code);
+    
+    // use browser/platform lang if available
+    let userLang = (this.win.navigator.language && this.win.navigator.language.split('-')[0]) || this.defaultLanguage.code;
 
     // init the lang
     this.store.dispatch(new ChangeAction(userLang));
+  }
+
+  changeLang(lang: string): void {
+    // change the lang
+    this.store.dispatch(new ChangeAction(lang));
   }
 }

--- a/src/client/app/frameworks/i18n/states/multilingual.state.ts
+++ b/src/client/app/frameworks/i18n/states/multilingual.state.ts
@@ -5,7 +5,7 @@ export interface IMultilingualState {
 }
 
 export const initialState: IMultilingualState = {
-  lang: 'en'
+  lang: ''
 };
 
 export function getLang(state$: Observable<IMultilingualState>) {

--- a/src/client/app/frameworks/i18n/testing/index.ts
+++ b/src/client/app/frameworks/i18n/testing/index.ts
@@ -18,10 +18,3 @@ export function TEST_MULTILINGUAL_PROVIDERS(): Array<any> {
 
   return providers;
 }
-
-export function TEST_MULTILINGUAL_RESET(): void {
-  // ensure static is reset
-  MultilingualService.SUPPORTED_LANGUAGES = [
-    { code: 'en', title: 'English' }
-  ];
-}

--- a/src/client/web.module.ts
+++ b/src/client/web.module.ts
@@ -33,12 +33,6 @@ if (String('<%= BUILD_TYPE %>') === 'dev') {
   Config.DEBUG.LEVEL_4 = true;
 }
 
-// sample config (extra)
-import { AppConfig } from './app/frameworks/sample/services/app-config';
-import { MultilingualService } from './app/frameworks/i18n/services/multilingual.service';
-// custom i18n language support
-MultilingualService.SUPPORTED_LANGUAGES = AppConfig.SUPPORTED_LANGUAGES;
-
 let routerModule = RouterModule.forRoot(routes);
 
 if (String('<%= TARGET_DESKTOP %>') === 'true') {


### PR DESCRIPTION
Here is the PR which provides a basic integration of ng2-config utility with i18n. I know it's not perfect yet, but it now allows us to configure the default language and available languages on app.config.json file, and access to their values from multilingual service's instance.

I tried my best to adapt the unit tests for multilingual service and lang switcher component. However, I have left several artifacts (such as MultilingualService.SUPPORTED_LANGUAGES), in order to do not break existing functionality which might be still in use - unless revised.

Please keep in mind, I'm open to any suggestions about providing config values for other components and services too.

On the other hand, ng2-metadata is on its way now :)