### PR TITLE
chore: rename ng2-translate to @ngx-translate/core

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -49,7 +49,7 @@ module.exports = function (config) {
 
       // Advanced seed
       { pattern: 'node_modules/lodash/**/*.js', included: false, watched: false },
-      { pattern: 'node_modules/ng2-translate/**/*.js', included: false, watched: false },
+      { pattern: 'node_modules/@ngx-translate/**/*.js', included: false, watched: false },
       { pattern: 'node_modules/@ngrx/**/*.js', included: false, watched: false },
       { pattern: 'node_modules/angulartics2/**/*.js', included: false, watched: false },
       { pattern: 'node_modules/ngrx-store-freeze/**/*.js', included: false, watched: false },

--- a/nativescript/package.json
+++ b/nativescript/package.json
@@ -46,7 +46,7 @@
     "nativescript-angular": "next",
     "nativescript-dev-webpack": "^0.3.1",
     "nativescript-theme-core": "^1.0.2",
-    "ng2-translate": "^5.0.0",
+    "@ngx-translate/core": "^6.0.0-beta.1",
     "ngrx-store-freeze": "0.1.6",
     "reflect-metadata": "^0.1.8",
     "rxjs": "~5.0.3",

--- a/nativescript/src/components.module.ts
+++ b/nativescript/src/components.module.ts
@@ -11,7 +11,7 @@ import { Http } from '@angular/http';
 import { NgModule, CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA } from '@angular/core';
 
 // libs
-import { TranslateModule, TranslateLoader, TranslateStaticLoader } from 'ng2-translate';
+import { TranslateModule, TranslateLoader, TranslateStaticLoader } from '@ngx-translate/core';
 
 // app
 import { AppComponent } from './app/components/app.component';

--- a/nativescript/src/mobile/core/services/ns-app.service.ts
+++ b/nativescript/src/mobile/core/services/ns-app.service.ts
@@ -14,7 +14,7 @@ if (isIOS) {
 
 // libs
 import { Store } from '@ngrx/store';
-import { TranslateService } from 'ng2-translate';
+import { TranslateService } from '@ngx-translate/core';
 
 // app
 import { AppService } from '../../../app/shared/core/services/app.service';

--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
     "intl": "^1.2.5",
     "lodash": "^4.17.4",
     "minimatch": "^3.0.3",
-    "ng2-translate": "^5.0.0",
+    "@ngx-translate/core": "^6.0.0-beta.1",
     "reflect-metadata": "^0.1.8",
     "rxjs": "~5.0.3",
     "systemjs": "0.19.41",

--- a/src/client/app/shared/i18n/multilingual.module.ts
+++ b/src/client/app/shared/i18n/multilingual.module.ts
@@ -6,7 +6,7 @@ import { RouterModule } from '@angular/router';
 import { HttpModule, Http } from '@angular/http';
 
 // libs
-import { TranslateModule, TranslateLoader, TranslateStaticLoader } from 'ng2-translate';
+import { TranslateModule, TranslateLoader, TranslateStaticLoader } from '@ngx-translate/core';
 
 // app
 import { Config } from '../core/index';

--- a/src/client/app/shared/i18n/services/multilingual.service.ts
+++ b/src/client/app/shared/i18n/services/multilingual.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 
 // libs
 import { Store } from '@ngrx/store';
-import { TranslateService } from 'ng2-translate';
+import { TranslateService } from '@ngx-translate/core';
 
 // app
 import { Analytics, AnalyticsService } from '../../analytics/index';

--- a/src/client/app/shared/i18n/testing/index.ts
+++ b/src/client/app/shared/i18n/testing/index.ts
@@ -1,5 +1,5 @@
 // libs
-import { TranslateService, TranslateLoader } from 'ng2-translate';
+import { TranslateService, TranslateLoader } from '@ngx-translate/core';
 
 // module
 import { MultilingualService } from '../index';

--- a/src/client/web.module.ts
+++ b/src/client/web.module.ts
@@ -9,7 +9,7 @@ import { Http } from '@angular/http';
 import { StoreModule } from '@ngrx/store';
 import { EffectsModule } from '@ngrx/effects';
 import { StoreDevtoolsModule } from '@ngrx/store-devtools';
-import { TranslateLoader } from 'ng2-translate';
+import { TranslateLoader } from '@ngx-translate/core';
 
 // app
 import { APP_COMPONENTS, AppComponent } from './app/components/index';

--- a/tools/config/seed-advanced.config.ts
+++ b/tools/config/seed-advanced.config.ts
@@ -107,7 +107,7 @@ export class SeedAdvancedConfig extends SeedConfig {
         }
       },
       {
-        name: 'ng2-translate',
+        name: '@ngx-translate/core',
         packageMeta: {
           main: 'bundles/index.js',
           defaultExtension: 'js'


### PR DESCRIPTION
In this PR, mappings for `ng2-translate` have been replaced with `@ngx-translate/core`.