### PR TITLE
Rename misnamed (typo) function 'wihtoutStringifiedEnvConfig'

### DIFF
--- a/tools/tasks/seed/build.index.dev.ts
+++ b/tools/tasks/seed/build.index.dev.ts
@@ -17,7 +17,7 @@ export = () => {
     .pipe(inject('shims'))
     .pipe(inject('libs'))
     .pipe(inject())
-    .pipe(plugins.template(new TemplateLocalsBuilder().wihtoutStringifiedEnvConfig().build()))
+    .pipe(plugins.template(new TemplateLocalsBuilder().withoutStringifiedEnvConfig().build()))
     .pipe(gulp.dest(Config.APP_DEST));
 };
 

--- a/tools/tasks/seed/build.index.prod.ts
+++ b/tools/tasks/seed/build.index.prod.ts
@@ -16,7 +16,7 @@ export = () => {
   return gulp.src(join(Config.APP_SRC, 'index.html'))
     .pipe(injectJs())
     .pipe(injectCss())
-    .pipe(plugins.template(new TemplateLocalsBuilder().wihtoutStringifiedEnvConfig().build()))
+    .pipe(plugins.template(new TemplateLocalsBuilder().withoutStringifiedEnvConfig().build()))
     .pipe(gulp.dest(Config.APP_DEST));
 };
 

--- a/tools/utils/seed/template_locals.ts
+++ b/tools/utils/seed/template_locals.ts
@@ -17,7 +17,7 @@ export class TemplateLocalsBuilder {
     this.stringifySystemConfigDev = true;
     return this;
   }
-  wihtoutStringifiedEnvConfig() {
+  withoutStringifiedEnvConfig() {
     this.stringifyEnvConfig = false;
     return this;
   }


### PR DESCRIPTION
Change misnamed function 'wihtoutStringifiedEnvConfig' to 'withoutStringifiedEnvConfig'.