### PR TITLE
Nativescript forms

### DIFF
--- a/nativescript/src/platform.module.ts
+++ b/nativescript/src/platform.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import {
+  NativeScriptFormsModule
+} from 'nativescript-angular';
+
+@NgModule({
+  imports: [
+    NativeScriptFormsModule
+  ],
+  exports: [
+    NativeScriptFormsModule
+  ]
+})
+export class PlatformModule { }

--- a/src/client/app/shared/sample/sample.module.ts
+++ b/src/client/app/shared/sample/sample.module.ts
@@ -1,7 +1,7 @@
 // angular
 import { NgModule, Optional, SkipSelf, NO_ERRORS_SCHEMA, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
+import { PlatformModule } from '../../../platform.module';
 import { HttpModule } from '@angular/http';
 import { RouterModule } from '@angular/router';
 
@@ -17,7 +17,7 @@ import { MultilingualModule } from '../i18n/multilingual.module';
 @NgModule({
   imports: [
     CommonModule,
-    FormsModule,
+    PlatformModule,
     HttpModule,
     RouterModule,
     MultilingualModule,

--- a/src/client/platform.module.ts
+++ b/src/client/platform.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+@NgModule({
+  imports: [
+    FormsModule
+  ],
+  exports: [
+    FormsModule
+  ]
+})
+export class PlatformModule { }


### PR DESCRIPTION
This fixes the issue that you need to import either the angular forms
module or the nativesciptformsmodule

Exporting it from a platform module outside of the shared app folder
means you can change the implementation.

This should fix issue #365 Error NativeScriptFormsModule import in browser 