### PR TITLE
fix: nativescript build template interpolation

### DIFF
--- a/tools/tasks/seed/build.index.dev.ts
+++ b/tools/tasks/seed/build.index.dev.ts
@@ -17,7 +17,10 @@ export = () => {
     .pipe(inject('shims'))
     .pipe(inject('libs'))
     .pipe(inject())
-    .pipe(plugins.template(new TemplateLocalsBuilder().withoutStringifiedEnvConfig().build()))
+    .pipe(plugins.template(
+      new TemplateLocalsBuilder().withoutStringifiedEnvConfig().build(),
+      {interpolate: /<%=([\s\S]+?)%>/g}
+    ))
     .pipe(gulp.dest(Config.APP_DEST));
 };
 

--- a/tools/tasks/seed/build.index.prod.ts
+++ b/tools/tasks/seed/build.index.prod.ts
@@ -16,7 +16,10 @@ export = () => {
   return gulp.src(join(Config.APP_SRC, 'index.html'))
     .pipe(injectJs())
     .pipe(injectCss())
-    .pipe(plugins.template(new TemplateLocalsBuilder().withoutStringifiedEnvConfig().build()))
+    .pipe(plugins.template(
+      new TemplateLocalsBuilder().withoutStringifiedEnvConfig().build(),
+      {interpolate: /<%=([\s\S]+?)%>/g}
+    ))
     .pipe(gulp.dest(Config.APP_DEST));
 };
 

--- a/tools/tasks/seed/build.js.dev.ts
+++ b/tools/tasks/seed/build.js.dev.ts
@@ -68,7 +68,10 @@ export =
         //      sourceRoot: (file: any) =>
         //        relative(file.path, Config.PROJECT_ROOT + '/' + Config.APP_SRC).replace(sep, '/') + '/' + Config.APP_SRC
         //    }))
-        .pipe(plugins.template(new TemplateLocalsBuilder().withStringifiedSystemConfigDev().build()))
+        .pipe(plugins.template(
+          new TemplateLocalsBuilder().withStringifiedSystemConfigDev().build(),
+          {interpolate: /<%=([\s\S]+?)%>/g}
+        ))
         .pipe(gulp.dest(Config.APP_DEST));
     }
   };

--- a/tools/tasks/seed/build.js.e2e.ts
+++ b/tools/tasks/seed/build.js.e2e.ts
@@ -24,6 +24,9 @@ export = () => {
 
   return result.js
     .pipe(plugins.sourcemaps.write())
-    .pipe(plugins.template(new TemplateLocalsBuilder().withStringifiedSystemConfigDev().build()))
+    .pipe(plugins.template(
+      new TemplateLocalsBuilder().withStringifiedSystemConfigDev().build(),
+      {interpolate: /<%=([\s\S]+?)%>/g}
+    ))
     .pipe(gulp.dest(Config.E2E_DEST));
 };

--- a/tools/tasks/seed/build.js.prod.aot.ts
+++ b/tools/tasks/seed/build.js.prod.aot.ts
@@ -32,7 +32,10 @@ export = () => {
     });
 
   return result.js
-    .pipe(plugins.template(new TemplateLocalsBuilder().build()))
+    .pipe(plugins.template(
+      new TemplateLocalsBuilder().build(),
+      {interpolate: /<%=([\s\S]+?)%>/g}
+    ))
     .pipe(gulp.dest(Config.TMP_DIR))
     .on('error', (e: any) => {
       console.log(e);

--- a/tools/tasks/seed/build.js.prod.ts
+++ b/tools/tasks/seed/build.js.prod.ts
@@ -35,7 +35,7 @@ export = () => {
 
 
   return result.js
-    .pipe(plugins.template(new TemplateLocalsBuilder().build()))
+    .pipe(plugins.template(new TemplateLocalsBuilder().build()), {interpolate: /<%=([\s\S]+?)%>/g})
     .pipe(gulp.dest(Config.TMP_DIR))
     .on('error', (e: any) => {
       console.log(e);

--- a/tools/tasks/seed/build.js.tns.ts
+++ b/tools/tasks/seed/build.js.tns.ts
@@ -52,16 +52,6 @@ export =
         },
       );
 
-    //   const envConfig = Object.assign({}, baseConfig, envOnlyConfig);
-    // let locals = Object.assign({},
-    //   Config,
-    //   { ENV_CONFIG: this.stringifyEnvConfig ? JSON.stringify(envConfig) : envConfig }
-    // );
-    // if (this.stringifySystemConfigDev) {
-    //   Object.assign(locals, {SYSTEM_CONFIG_DEV: JSON.stringify(Config.SYSTEM_CONFIG_DEV)});
-    // }
-    // return locals;
-
       const transpiled = result.js
         .pipe(plugins.sourcemaps.write())
         // Use for debugging with Webstorm/IntelliJ
@@ -71,9 +61,7 @@ export =
         //      sourceRoot: (file: any) =>
         //        relative(file.path, PROJECT_ROOT + '/' + APP_SRC).replace(sep, '/') + '/' + APP_SRC
         //    }))
-
-        // TODO: template does not work on ns-app.service - not sure why - disabled for now
-        // .pipe(plugins.template(template, {})).on('error', console.error.bind(console))
+        .pipe(plugins.template(template, {interpolate: /<%=([\s\S]+?)%>/g}))
         .pipe(gulp.dest(Config.TNS_APP_DEST));
 
       const copy = gulp.src(src, {

--- a/tools/tasks/seed/build.tools.ts
+++ b/tools/tasks/seed/build.tools.ts
@@ -25,7 +25,7 @@ export = () => {
     .pipe(tsProject());
 
   return result.js
-    .pipe(plugins.template(new TemplateLocalsBuilder().build()))
+    .pipe(plugins.template(new TemplateLocalsBuilder().build(), {interpolate: /<%=([\s\S]+?)%>/g}))
     .pipe(plugins.sourcemaps.write())
     .pipe(gulp.dest('./'));
 };

--- a/tools/tasks/seed/transpile.bundles.rollup.aot.ts
+++ b/tools/tasks/seed/transpile.bundles.rollup.aot.ts
@@ -28,7 +28,7 @@ export = () => {
     });
 
   return result.js
-    .pipe(plugins.template(new TemplateLocalsBuilder().build()))
+    .pipe(plugins.template(new TemplateLocalsBuilder().build(), {interpolate: /<%=([\s\S]+?)%>/g}))
     .pipe(plugins.rename(Config.JS_PROD_APP_BUNDLE))
     .pipe(gulp.dest(Config.JS_DEST))
     .on('error', (e: any) => {


### PR DESCRIPTION
This disables the ES template literal interpolation `${ ... }` that was
causing the tns js build to fail due to comments containing that pattern
and the corresponding interpolation param not being found.

Specifically this bit of commented out code in the ns-app.service file:
```
// this.log.info(`NSAppComponent translate.onLangChange(${args.lang})`);
```

I disabled it in all calls to the gulp template plugin for consistency, but I can revert it to just the steps that effect this specific issue if you'd prefer.

Related lodash issue: https://github.com/lodash/lodash/issues/399