### PR TITLE
Fixed yargs non-hyphenated options 

### DIFF
--- a/tools/config/seed-advanced.config.ts
+++ b/tools/config/seed-advanced.config.ts
@@ -33,7 +33,7 @@ export class SeedAdvancedConfig extends SeedConfig {
 
     let arg: string;
     if (argv && argv._) {
-      arg = argv._[0];
+      arg = argv._;
       if (arg.indexOf('desktop') > -1) {
         this.TARGET_DESKTOP = true;
         if (arg.indexOf('.mac') > -1 || arg.indexOf('.windows') > -1 || arg.indexOf('.linux') > -1) {


### PR DESCRIPTION
The problem can be found by running `npm run tasks.list`. This commit fixes the exception that results